### PR TITLE
Fix channel label issue #251, clarify two names, refactor the bundled samplepack strings

### DIFF
--- a/editor/AddSamplesPrompt.ts
+++ b/editor/AddSamplesPrompt.ts
@@ -1,5 +1,5 @@
 import { HTML, SVG } from "imperative-html/dist/esm/elements-strict";
-import { Dictionary, Config } from "../synth/SynthConfig";
+import { Dictionary, Config, bundledSamplePacks } from "../synth/SynthConfig";
 import { clamp, parseFloatWithDefault, parseIntWithDefault } from "../synth/synth";
 import { ColorConfig } from "./ColorConfig";
 import { EditorConfig } from "./EditorConfig";
@@ -49,11 +49,11 @@ export class AddSamplesPrompt {
     private readonly _description: HTMLDivElement = div(
         div({ style: "margin-bottom: 0.5em; -webkit-user-select: text; -moz-user-select: text; -ms-user-select: text; user-select: text; cursor: text;" },
             "In order to use the old UltraBox samples, you should add ",
-            code("legacySamples"),
+            code(bundledSamplePacks.legacy),
             " as an URL. You can also use ",
-            code("nintariboxSamples"),
+            code(bundledSamplePacks.nintaribox),
             " and ",
-            code("marioPaintboxSamples"),
+            code(bundledSamplePacks.mariopaintbox),
             " for more built-in sample packs."
         ),
         div({ style: "margin-bottom: 0.5em;" },
@@ -438,10 +438,10 @@ export class AddSamplesPrompt {
         const parsedEntries: SampleEntry[] = [];
         for (const url of urls) {
             if (url === "") continue;
-            if (url.toLowerCase() === "legacysamples") {
+            if (url.toLowerCase() === bundledSamplePacks.legacy) {
                 if (!useLegacySamples) {
                     parsedEntries.push({
-                        url: "legacySamples",
+                        url: bundledSamplePacks.legacy,
                         sampleRate: 44100,
                         rootKey: 60,
                         percussion: false,
@@ -453,10 +453,10 @@ export class AddSamplesPrompt {
                     });
                 }
                 useLegacySamples = true;
-            } else if (url.toLowerCase() === "nintariboxsamples") {
+            } else if (url.toLowerCase() === bundledSamplePacks.nintaribox) {
                 if (!useNintariboxSamples) {
                     parsedEntries.push({
-                        url: "nintariboxSamples",
+                        url: bundledSamplePacks.nintaribox,
                         sampleRate: 44100,
                         rootKey: 60,
                         percussion: false,
@@ -468,10 +468,10 @@ export class AddSamplesPrompt {
                     });
                 }
                 useNintariboxSamples = true;
-            } else if (url.toLowerCase() === "mariopaintboxsamples") {
+            } else if (url.toLowerCase() === bundledSamplePacks.mariopaintbox) {
                 if (!useMarioPaintboxSamples) {
                     parsedEntries.push({
-                        url: "marioPaintboxSamples",
+                        url: bundledSamplePacks.mariopaintbox,
                         sampleRate: 44100,
                         rootKey: 60,
                         percussion: false,
@@ -584,11 +584,7 @@ export class AddSamplesPrompt {
         const chipWaveLoopMode: number | null = entry.chipWaveLoopMode;
         const chipWavePlayBackwards: boolean = entry.chipWavePlayBackwards;
         const urlInLowerCase: string = url.toLowerCase();
-        const isBundledSamplePack: boolean = (
-            urlInLowerCase === "legacysamples"
-            || urlInLowerCase === "nintariboxsamples"
-            || urlInLowerCase === "mariopaintboxsamples"
-        );
+        const isBundledSamplePack: boolean = Object.keys(bundledSamplePacks).includes(urlInLowerCase);
         const options: string[] = [];
         if (sampleRate !== 44100) options.push("s" + sampleRate);
         if (rootKey !== 60) options.push("r" + rootKey);

--- a/editor/ColorConfig.ts
+++ b/editor/ColorConfig.ts
@@ -5615,6 +5615,7 @@ export class ColorConfig {
     public static readonly blackPianoKey: string = "var(--black-piano-key, #444)";
     public static readonly whitePianoKeyText: string = "var(--white-piano-key-text, #131200)";
     public static readonly blackPianoKeyText: string = "var(--black-piano-key-text, #fff)";
+
 	//public static readonly oscilloscopeLineL: string = "var(--oscilloscope-line-L, var(--primary-text, white))";
 	//public static readonly oscilloscopeLineR: string = "var(--oscilloscope-line-R, var(--text-selection, rgba(119,68,255,0.99)))";
 	// modTitle can stay uncommented until it's used somwhere that's not index.html

--- a/editor/EditorTabSelection.ts
+++ b/editor/EditorTabSelection.ts
@@ -1,0 +1,179 @@
+import { ColorConfig } from "./ColorConfig";
+import { HTML } from "imperative-html/dist/esm/elements-strict";
+import { Slider } from "./HTMLWrapper";
+import { PatternEditor, SelectionMode } from "./PatternEditor";
+import { SongDocument } from "./SongDocument";
+
+const { button, div, label, input } = HTML;
+
+/** This contains the controls for the Selection tab in the song editor. */
+export class EditorTabSelection {
+    public htmlEntryPoint: HTMLDivElement;
+
+    private _doc: SongDocument;
+    private _patternEditor: PatternEditor;
+    private _selectionModeMoveLabel: HTMLDivElement;
+    private _selectionModeStretchLabel : HTMLDivElement;
+    private _selectionModeLabel : HTMLDivElement;
+    private _merge : HTMLButtonElement;
+    private _mergeAll : HTMLInputElement;
+    private _bridge : HTMLButtonElement;
+    private _bridgeBend : HTMLInputElement;
+    private _spread : HTMLButtonElement;
+    private _spreadPitch : HTMLInputElement;
+    private _flatten : HTMLButtonElement;
+    private _flattenPitch : HTMLInputElement;
+    private _mirrorH : HTMLButtonElement;
+    private _mirrorV : HTMLButtonElement;
+    private _split : HTMLButtonElement;
+    private _splitSlider : Slider;
+    private _splitAbsolute : HTMLInputElement;
+    private _splitAcross : HTMLInputElement;
+    private _splitLabel : HTMLDivElement;
+
+    constructor(doc: SongDocument, patternEditor: PatternEditor, tipHandler: (tipName: string) => void) {
+        this._doc = doc;
+        this._patternEditor = patternEditor;
+        this._constructHTML(tipHandler);
+    }
+
+    private _constructHTML(tipHandler: (tipName: string) => void) {
+        const _selectionOpsDescription = div({ style: `padding: 3px 0; max-width: 15em; text-align: center; color: ${ColorConfig.secondaryText};` }, "Selection");
+        this._selectionModeLabel = div({ style: `padding: 3px 0; color: ${ColorConfig.secondaryText};` }, "Move mode");
+        const _selectionModeBtnMove = input({ type: "radio", name: "selection-mode-radio-group", class: "tab-settings-radio" });
+        this._selectionModeMoveLabel = div({ class: "tab-settings-radio selected-tab" }, "↤");
+        const _selectionModeBtnStretch = input({ type: "radio", name: "selection-mode-radio-group", class: "tab-settings-radio" });
+        this._selectionModeStretchLabel = div({ class: "tab-settings-radio" }, "↔");
+        const  _selectionModeButtonsGroup: HTMLDivElement = div({ class: "tab-settings-buttons-group" },
+            div({ class: "tab-settings-radiodiv" }, _selectionModeBtnMove, this._selectionModeMoveLabel),
+            div({ class: "tab-settings-radiodiv" }, _selectionModeBtnStretch, this._selectionModeStretchLabel)
+        );
+        this._merge = button({ class: "selectionOps-actionbutton noteOpMerge" });
+        this._mergeAll = input({ type: "checkbox", class: "selectionOps-checkbox"});
+        this._bridge = button({ class: "selectionOps-actionbutton noteOpBridge" });
+        this._bridgeBend = input({ type: "checkbox", class: "selectionOps-checkbox"});
+        this._spread = button({ class: "selectionOps-actionbutton noteOpSpread" });
+        this._spreadPitch = input({ type: "checkbox", class: "selectionOps-checkbox"});
+        this._mirrorH = button({ class: "selectionOps-actionbutton noteOpMirror" });
+        this._mirrorV = button({ class: "selectionOps-actionbutton noteOpMirror", style: 'transform: rotate(90deg);' });
+        this._flatten = button({ class: "selectionOps-actionbutton noteOpFlatten" });
+        this._flattenPitch = input({ type: "checkbox", class: "selectionOps-checkbox"});
+        this._split = button({ class: "selectionOps-actionbutton noteOpSplit" });
+        this._splitLabel = div({ class: "tip", onclick: () => tipHandler("selectionSplit") }, "");
+        this._splitSlider = new Slider(
+            input({ title: "cuts", style: "width: 6rem; flex-grow: 1; margin-left: 0.5rem;", type: "range", min: "1", max: String(Math.floor(this._doc.song.partsPerPattern / 2)), value: "1", step: "1" }), this._doc, null, false);
+        this._splitAcross = input({ type: "checkbox", class: "selectionOps-checkbox"});
+        this._splitAbsolute = input({ type: "checkbox", class: "selectionOps-checkbox"});
+        const _selectionOpsRow1 = div({ class: "selectionOps-row"},
+            div({ class: "selectionOps-action"},
+                div({ class: "tip", onclick: () => tipHandler("selectionMerge") }, "Merge"),
+                div({ class: "selectionOps-action-controls"},
+                    this._merge,
+                    label({ class: "checkbox-container" }, this._mergeAll, "All"))),
+            div({ class: "selectionOps-action"},
+                div({ class: "tip", onclick: () => tipHandler("selectionBridge") }, "Bridge"),
+                div({ class: "selectionOps-action-controls"},
+                    this._bridge,
+                    label({ class: "checkbox-container" }, this._bridgeBend, "Bend"))),
+            div({ class: "selectionOps-action"},
+                div({ class: "tip", onclick: () => tipHandler("selectionSpread") }, "Spread"),
+                div({ class: "selectionOps-action-controls"},
+                    this._spread,
+                    label({ class: "checkbox-container" }, this._spreadPitch, "Pitch")))
+        );
+
+        const _selectionOpsRow2 = div({ class: "selectionOps-row"},
+            div({ class: "selectionOps-action"},
+                div({ class: "tip", onclick: () => tipHandler("selectionMirror") }, "Mirror"),
+                div({ class: "selectionOps-row-inside"},
+                    div({ class: "selectionOps-action-controls"}, this._mirrorH),
+                    div({ class: "selectionOps-action-controls"}, this._mirrorV))),
+            div({ class: "selectionOps-action"},
+                div({ class: "tip", onclick: () => tipHandler("selectionFlatten") }, "Flatten"),
+                div({ class: "selectionOps-action-controls"},
+                    this._flatten,
+                    label({ class: "checkbox-container" }, this._flattenPitch, "Pitch")))
+        );
+
+        const _selectionOpsRow3 = div({ class: "selectionOps-row"},
+            div({ class: "selectionOps-action"},
+                this._splitLabel,
+                div({ class: "selectionOps-action-controls"},
+                    div({ class: "selectionOps-row-inside"},
+                        this._split,
+                        this._splitSlider.container),
+                    div({ class: "selectionOps-row-inside"},
+                        label({ class: "checkbox-container" }, this._splitAcross, "Across"),
+                        label({ class: "checkbox-container" }, this._splitAbsolute, "Absolute"))))
+        );
+
+        _selectionModeBtnMove.addEventListener("change", () => this._whenSelectionModeChanged(SelectionMode.Move));
+        _selectionModeBtnStretch.addEventListener("change", () => this._whenSelectionModeChanged(SelectionMode.Stretch));
+
+        [this._merge, this._bridge, this._spread,
+            this._mirrorH, this._mirrorV, this._flatten,
+            this._split]
+            .forEach((o) => o.addEventListener("click", this._whenSettingButtonClicked));
+
+        this._splitSlider.input.addEventListener("input", this._updateSplitSliderLabel);
+        this._splitSlider.input.addEventListener("change", this._updateSplitSliderLabel);
+        this._splitAcross.addEventListener("change", this._updateSplitSliderLabel);
+        this._splitAbsolute.addEventListener("change", this._updateSplitSliderLabel);
+        this._updateSplitSliderLabel(); // Set initial label.
+
+        this.htmlEntryPoint = div({},
+            _selectionOpsDescription,
+            this._selectionModeLabel,
+            _selectionModeButtonsGroup,
+            _selectionOpsRow1,
+            _selectionOpsRow2,
+            _selectionOpsRow3);
+    }
+
+    private _whenSelectionModeChanged = (type: SelectionMode): void => {
+        [
+            {type: SelectionMode.Move, obj: this._selectionModeMoveLabel},
+            {type: SelectionMode.Stretch, obj: this._selectionModeStretchLabel}
+        ].forEach((entry) => {
+            if (type == entry.type) {
+                if (!entry.obj.classList.contains('selected-tab')) { entry.obj.classList.add('selected-tab') }
+            } else {
+                entry.obj.classList.remove('selected-tab')
+            }
+        })
+
+        this._patternEditor.switchEditingMode(type);
+        this._selectionModeLabel.innerText = (type === SelectionMode.Move) ? "Move mode" : "Stretch mode";
+    }
+
+    private _whenSettingButtonClicked = (event: MouseEvent): void => {
+        if (event.target === this._merge) {
+            this._doc.selection.noteMerge(!this._mergeAll.checked);
+        } else if (event.target === this._bridge) {
+            this._doc.selection.noteBridge(this._bridgeBend.checked, false);
+        } else if (event.target === this._spread) {
+            this._doc.selection.noteSpreadAcross(this._spreadPitch.checked);
+        } else if (event.target === this._flatten) {
+            this._doc.selection.noteFlattenAcross(!this._flattenPitch.checked);
+        } else if (event.target === this._mirrorH) {
+            this._doc.selection.noteMirrorAcross(false);
+        } else if (event.target === this._mirrorV) {
+            this._doc.selection.noteMirrorAcross(true);
+        } else if (event.target === this._split) {
+            this._doc.selection.noteSplitAcross(Number(this._splitSlider.input.value),
+            this._splitAbsolute.checked, !this._splitAcross.checked)
+        }
+    }
+
+    private _updateSplitSliderLabel = (): void => {
+        const num = this._splitSlider.input.valueAsNumber;
+        this._splitLabel.innerText =
+            this._splitAcross.checked && !this._splitAbsolute.checked
+                ? `Split ${num} times`:
+            !this._splitAcross.checked && !this._splitAbsolute.checked
+                ? `Split each note ${num} times`:
+            !this._splitAcross.checked && this._splitAbsolute.checked
+                ? `Split every ${num} parts per note`:
+            `Split every ${num} parts`;
+    }
+}

--- a/editor/EditorTabSelection.ts
+++ b/editor/EditorTabSelection.ts
@@ -36,6 +36,8 @@ export class EditorTabSelection {
     private _splitAbsolute : HTMLInputElement;
     private _splitAcross : HTMLInputElement;
     private _splitLabel : HTMLDivElement;
+    private _stepFunctionSelect: HTMLSelectElement;
+    
 
     constructor(doc: SongDocument, patternEditor: PatternEditor, tipHandler: TipHandler) {
         this._doc = doc;
@@ -68,6 +70,7 @@ export class EditorTabSelection {
         this._split = button({ class: "selectionOps-actionbutton noteOpSplit" });
         this._splitLabel = div({ class: "tip", onclick: () => tipHandler("selectionSplit") }, "");
         this._splitDropdown = button({ style: "height:1.5em; width: 10px; padding: 0px; font-size: 8px; margin-left: 0.2rem;" }, "▼");
+        this._stepFunctionSelect = buildOptions(select(), Config.chipWaves.map(wave => wave.name));
 
         this._splitSliderInputBox = input({ type: "number", step: "1", min: 1, max: Math.floor(this._doc.song.partsPerPattern / 2), value: "1" });
         this._splitSlider = new Slider(

--- a/editor/EditorTabSelection.ts
+++ b/editor/EditorTabSelection.ts
@@ -65,10 +65,11 @@ export class EditorTabSelection {
         this._flattenPitch = input({ type: "checkbox", class: "selectionOps-checkbox"});
         this._split = button({ class: "selectionOps-actionbutton noteOpSplit" });
         this._splitLabel = div({ class: "tip", onclick: () => tipHandler("selectionSplit") }, "");
+        this._splitDropdown = button({ style: "height:1.5em; width: 10px; padding: 0px; font-size: 8px; margin-left: 0.2rem;" }, "▼");
+
+        this._splitSliderInputBox = input({ type: "number", step: "1", min: 1, max: Math.floor(this._doc.song.partsPerPattern / 2), value: "1" });
         this._splitSlider = new Slider(
             input({ title: "cuts", style: "width: 6rem; flex-grow: 1; margin-left: 0.5rem;", type: "range", min: "1", max: String(Math.floor(this._doc.song.partsPerPattern / 2)), value: "1", step: "1" }), this._doc, null, false);
-        this._splitSliderInputBox = input({ type: "number", step: "1", min: 1, max: Math.floor(this._doc.song.partsPerPattern / 2), value: "1" });
-        this._splitDropdown = button({ style: "height:1.5em; width: 10px; padding: 0px; font-size: 8px; margin-left: 0.2rem;" }, "▼");
         this._splitAcross = input({ type: "checkbox", class: "selectionOps-checkbox"});
         this._splitAbsolute = input({ type: "checkbox", class: "selectionOps-checkbox"});
         this._splitDropdownGroup = div({ class: "editor-controls", style: "display: none;" },
@@ -158,7 +159,7 @@ export class EditorTabSelection {
         if (event.target === this._merge) {
             this._doc.selection.noteMerge(!this._mergeAll.checked);
         } else if (event.target === this._bridge) {
-            this._doc.selection.noteBridge(this._bridgeBend.checked, false);
+            this._doc.selection.noteBridge(this._bridgeBend.checked);
         } else if (event.target === this._spread) {
             this._doc.selection.noteSpreadAcross(this._spreadPitch.checked);
         } else if (event.target === this._flatten) {

--- a/editor/EditorTabSelection.ts
+++ b/editor/EditorTabSelection.ts
@@ -25,6 +25,7 @@ export class EditorTabSelection {
     private _spreadPitch : HTMLInputElement;
     private _flatten : HTMLButtonElement;
     private _flattenPitch : HTMLInputElement;
+    private _flattenVolume : HTMLInputElement;
     private _mirrorH : HTMLButtonElement;
     private _mirrorV : HTMLButtonElement;
     private _split : HTMLButtonElement;
@@ -63,6 +64,7 @@ export class EditorTabSelection {
         this._mirrorV = button({ class: "selectionOps-actionbutton noteOpMirror", style: 'transform: rotate(90deg);' });
         this._flatten = button({ class: "selectionOps-actionbutton noteOpFlatten" });
         this._flattenPitch = input({ type: "checkbox", class: "selectionOps-checkbox"});
+        this._flattenVolume = input({ type: "checkbox", class: "selectionOps-checkbox"});
         this._split = button({ class: "selectionOps-actionbutton noteOpSplit" });
         this._splitLabel = div({ class: "tip", onclick: () => tipHandler("selectionSplit") }, "");
         this._splitDropdown = button({ style: "height:1.5em; width: 10px; padding: 0px; font-size: 8px; margin-left: 0.2rem;" }, "▼");
@@ -103,7 +105,8 @@ export class EditorTabSelection {
             div({ class: "selectionOps-action"},
                 this._flatten,
                 div({ class: "tip", onclick: () => tipHandler("selectionFlatten") }, "Flatten"),
-                label({ class: "checkbox-container" }, this._flattenPitch, "Pitch"))
+                label({ class: "checkbox-container" }, this._flattenPitch, "Pitch"),
+                label({ class: "checkbox-container" }, this._flattenVolume, "Vol"))
         ];
 
         const _selectionOpsRow3 = [
@@ -163,7 +166,7 @@ export class EditorTabSelection {
         } else if (event.target === this._spread) {
             this._doc.selection.noteSpreadAcross(this._spreadPitch.checked);
         } else if (event.target === this._flatten) {
-            this._doc.selection.noteFlattenAcross(!this._flattenPitch.checked);
+            this._doc.selection.noteFlattenAcross(!this._flattenPitch.checked, this._flattenVolume.checked);
         } else if (event.target === this._mirrorH) {
             this._doc.selection.noteMirrorAcross(false);
         } else if (event.target === this._mirrorV) {

--- a/editor/EditorTabSelection.ts
+++ b/editor/EditorTabSelection.ts
@@ -6,6 +6,8 @@ import { SongDocument } from "./SongDocument";
 
 const { button, div, label, input } = HTML;
 
+type TipHandler = (tipName: string) => void;
+
 /** This contains the controls for the Selection tab in the song editor. */
 export class EditorTabSelection {
     public htmlEntryPoint: HTMLDivElement;
@@ -27,24 +29,27 @@ export class EditorTabSelection {
     private _mirrorV : HTMLButtonElement;
     private _split : HTMLButtonElement;
     private _splitSlider : Slider;
+    private _splitSliderInputBox : HTMLInputElement;
+    private _splitDropdown: HTMLButtonElement;
+    private _splitDropdownGroup: HTMLDivElement;
     private _splitAbsolute : HTMLInputElement;
     private _splitAcross : HTMLInputElement;
     private _splitLabel : HTMLDivElement;
 
-    constructor(doc: SongDocument, patternEditor: PatternEditor, tipHandler: (tipName: string) => void) {
+    constructor(doc: SongDocument, patternEditor: PatternEditor, tipHandler: TipHandler) {
         this._doc = doc;
         this._patternEditor = patternEditor;
         this._constructHTML(tipHandler);
     }
 
-    private _constructHTML(tipHandler: (tipName: string) => void) {
+    private _constructHTML(tipHandler: TipHandler) {
         const _selectionOpsDescription = div({ style: `padding: 3px 0; max-width: 15em; text-align: center; color: ${ColorConfig.secondaryText};` }, "Selection");
         this._selectionModeLabel = div({ style: `padding: 3px 0; color: ${ColorConfig.secondaryText};` }, "Move mode");
         const _selectionModeBtnMove = input({ type: "radio", name: "selection-mode-radio-group", class: "tab-settings-radio" });
         this._selectionModeMoveLabel = div({ class: "tab-settings-radio selected-tab" }, "↤");
         const _selectionModeBtnStretch = input({ type: "radio", name: "selection-mode-radio-group", class: "tab-settings-radio" });
         this._selectionModeStretchLabel = div({ class: "tab-settings-radio" }, "↔");
-        const  _selectionModeButtonsGroup: HTMLDivElement = div({ class: "tab-settings-buttons-group" },
+        const  _selectionModeButtonsGroup: HTMLDivElement = div({ class: "tab-settings-buttons-group", style: "margin-bottom: 0.4rem;" },
             div({ class: "tab-settings-radiodiv" }, _selectionModeBtnMove, this._selectionModeMoveLabel),
             div({ class: "tab-settings-radiodiv" }, _selectionModeBtnStretch, this._selectionModeStretchLabel)
         );
@@ -62,72 +67,75 @@ export class EditorTabSelection {
         this._splitLabel = div({ class: "tip", onclick: () => tipHandler("selectionSplit") }, "");
         this._splitSlider = new Slider(
             input({ title: "cuts", style: "width: 6rem; flex-grow: 1; margin-left: 0.5rem;", type: "range", min: "1", max: String(Math.floor(this._doc.song.partsPerPattern / 2)), value: "1", step: "1" }), this._doc, null, false);
+        this._splitSliderInputBox = input({ type: "number", step: "1", min: 1, max: Math.floor(this._doc.song.partsPerPattern / 2), value: "1" });
+        this._splitDropdown = button({ style: "height:1.5em; width: 10px; padding: 0px; font-size: 8px; margin-left: 0.2rem;" }, "▼");
         this._splitAcross = input({ type: "checkbox", class: "selectionOps-checkbox"});
         this._splitAbsolute = input({ type: "checkbox", class: "selectionOps-checkbox"});
-        const _selectionOpsRow1 = div({ class: "selectionOps-row"},
+        this._splitDropdownGroup = div({ class: "editor-controls", style: "display: none;" },
+            div({ class: "selectionOps-row-inside"},
+                this._splitSliderInputBox,
+                this._splitSlider.container),
+            div({ class: "selectionOps-row-inside"},
+                label({ class: "checkbox-container" }, this._splitAcross, "Across"),
+                label({ class: "checkbox-container" }, this._splitAbsolute, "Absolute")));
+
+        const _selectionOpsRow1 = [
             div({ class: "selectionOps-action"},
+                this._merge,
                 div({ class: "tip", onclick: () => tipHandler("selectionMerge") }, "Merge"),
-                div({ class: "selectionOps-action-controls"},
-                    this._merge,
-                    label({ class: "checkbox-container" }, this._mergeAll, "All"))),
+                label({ class: "checkbox-container" }, this._mergeAll, "All")),
             div({ class: "selectionOps-action"},
+                this._bridge,
                 div({ class: "tip", onclick: () => tipHandler("selectionBridge") }, "Bridge"),
-                div({ class: "selectionOps-action-controls"},
-                    this._bridge,
-                    label({ class: "checkbox-container" }, this._bridgeBend, "Bend"))),
+                label({ class: "checkbox-container" }, this._bridgeBend, "Bend")),
             div({ class: "selectionOps-action"},
+                this._spread,
                 div({ class: "tip", onclick: () => tipHandler("selectionSpread") }, "Spread"),
-                div({ class: "selectionOps-action-controls"},
-                    this._spread,
-                    label({ class: "checkbox-container" }, this._spreadPitch, "Pitch")))
-        );
+                label({ class: "checkbox-container" }, this._spreadPitch, "Pitch"))
+        ];
 
-        const _selectionOpsRow2 = div({ class: "selectionOps-row"},
+        const _selectionOpsRow2 = [
             div({ class: "selectionOps-action"},
-                div({ class: "tip", onclick: () => tipHandler("selectionMirror") }, "Mirror"),
-                div({ class: "selectionOps-row-inside"},
-                    div({ class: "selectionOps-action-controls"}, this._mirrorH),
-                    div({ class: "selectionOps-action-controls"}, this._mirrorV))),
+                this._mirrorH,
+                this._mirrorV,
+                div({ class: "tip", onclick: () => tipHandler("selectionMirror") }, "Mirror")),
             div({ class: "selectionOps-action"},
+                this._flatten,
                 div({ class: "tip", onclick: () => tipHandler("selectionFlatten") }, "Flatten"),
-                div({ class: "selectionOps-action-controls"},
-                    this._flatten,
-                    label({ class: "checkbox-container" }, this._flattenPitch, "Pitch")))
-        );
+                label({ class: "checkbox-container" }, this._flattenPitch, "Pitch"))
+        ];
 
-        const _selectionOpsRow3 = div({ class: "selectionOps-row"},
+        const _selectionOpsRow3 = [
             div({ class: "selectionOps-action"},
+                this._split,
                 this._splitLabel,
-                div({ class: "selectionOps-action-controls"},
-                    div({ class: "selectionOps-row-inside"},
-                        this._split,
-                        this._splitSlider.container),
-                    div({ class: "selectionOps-row-inside"},
-                        label({ class: "checkbox-container" }, this._splitAcross, "Across"),
-                        label({ class: "checkbox-container" }, this._splitAbsolute, "Absolute"))))
-        );
+                this._splitDropdown),
+            this._splitDropdownGroup
+        ];
 
         _selectionModeBtnMove.addEventListener("change", () => this._whenSelectionModeChanged(SelectionMode.Move));
         _selectionModeBtnStretch.addEventListener("change", () => this._whenSelectionModeChanged(SelectionMode.Stretch));
+        this._splitDropdown.addEventListener("click", () => {
+            this._splitDropdownGroup.style.display = (this._splitDropdownGroup.style.display === "none" ? "" : "none")
+        });
 
-        [this._merge, this._bridge, this._spread,
-            this._mirrorH, this._mirrorV, this._flatten,
-            this._split]
+        [this._merge, this._bridge, this._spread, this._mirrorH, this._mirrorV, this._flatten, this._split]
             .forEach((o) => o.addEventListener("click", this._whenSettingButtonClicked));
 
-        this._splitSlider.input.addEventListener("input", this._updateSplitSliderLabel);
-        this._splitSlider.input.addEventListener("change", this._updateSplitSliderLabel);
-        this._splitAcross.addEventListener("change", this._updateSplitSliderLabel);
-        this._splitAbsolute.addEventListener("change", this._updateSplitSliderLabel);
-        this._updateSplitSliderLabel(); // Set initial label.
+        this._splitSliderInputBox.addEventListener("input", this._updateSplitSliderParts(this._splitSliderInputBox));
+        this._splitSlider.input.addEventListener("input", this._updateSplitSliderParts(this._splitSlider.input));
+        this._splitSlider.input.addEventListener("change", this._updateSplitSliderParts(this._splitSlider.input));
+        this._splitAcross.addEventListener("change", this._updateSplitSliderParts(this._splitSlider.input));
+        this._splitAbsolute.addEventListener("change", this._updateSplitSliderParts(this._splitSlider.input));
+        this._updateSplitSliderParts(this._splitSliderInputBox)(); // Set defaults.
 
         this.htmlEntryPoint = div({},
             _selectionOpsDescription,
             this._selectionModeLabel,
             _selectionModeButtonsGroup,
-            _selectionOpsRow1,
-            _selectionOpsRow2,
-            _selectionOpsRow3);
+            ..._selectionOpsRow1,
+            ..._selectionOpsRow2,
+            ..._selectionOpsRow3);
     }
 
     private _whenSelectionModeChanged = (type: SelectionMode): void => {
@@ -165,15 +173,22 @@ export class EditorTabSelection {
         }
     }
 
-    private _updateSplitSliderLabel = (): void => {
-        const num = this._splitSlider.input.valueAsNumber;
+    private _updateSplitSliderParts = (source: HTMLInputElement) => (): void => {
+        const newValue = source.valueAsNumber;
+        if (this._splitSliderInputBox.valueAsNumber !== newValue) {
+            this._splitSliderInputBox.value = String(newValue);
+        }
+        if (this._splitSlider.input.valueAsNumber !== newValue) {
+            this._splitSlider.updateValue(newValue);
+        }
+
         this._splitLabel.innerText =
             this._splitAcross.checked && !this._splitAbsolute.checked
-                ? `Split ${num} times`:
+                ? `Split across ${newValue} times`:
             !this._splitAcross.checked && !this._splitAbsolute.checked
-                ? `Split each note ${num} times`:
+                ? `Split notes ${newValue} times`:
             !this._splitAcross.checked && this._splitAbsolute.checked
-                ? `Split every ${num} parts per note`:
-            `Split every ${num} parts`;
+                ? `Split notes per ${newValue} parts`
+                : `Split across per ${newValue} parts`;
     }
 }

--- a/editor/Layout.ts
+++ b/editor/Layout.ts
@@ -38,11 +38,11 @@ export class Layout {
 					overflow: auto;
 					max-height: 97.5vh;
 				}
-				.beepboxEditor .instrument-settings-area {
+				.beepboxEditor .tab-controls-area {
 					overflow-y: auto;
 					position: relative;
 				}
-				.beepboxEditor .instrument-settings-area > .editor-controls {
+				.beepboxEditor tab-controls-area > instrument-settings > .editor-controls {
 					position: absolute;
 					width: 100%;
 				}
@@ -55,10 +55,10 @@ export class Layout {
 					grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 					grid-template-rows: auto auto auto minmax(0, 1fr);
 					grid-template-areas:
-						"instrument-settings-area version-area"
-						"instrument-settings-area play-pause-area"
-						"instrument-settings-area menu-area"
-						"instrument-settings-area song-settings-area";
+						"tab-controls-area version-area"
+						"tab-controls-area play-pause-area"
+						"tab-controls-area menu-area"
+						"tab-controls-area song-settings-area";
 				}
 				
 				.beepboxEditor .barScrollBar {
@@ -128,7 +128,7 @@ export class Layout {
 					flex-grow: 0;
 					max-height: 97.5vh;
 				}
-				.beepboxEditor .instrument-settings-area > .editor-controls {
+				.beepboxEditor tab-controls-area > instrument-settings > .editor-controls {
 					position: absolute;
 					width: 100%;
 				}
@@ -144,7 +144,7 @@ export class Layout {
 						"play-pause-area"
 						"menu-area"
 						"song-settings-area"
-						"instrument-settings-area";
+						"tab-controls-area";
 				}
 				.beepboxEditor .version-area {
 					position: sticky;
@@ -225,11 +225,11 @@ export class Layout {
 					overflow-y: auto;
 					max-height: 97.5vh;
 				}
-				.beepboxEditor .instrument-settings-area {
+				.beepboxEditor .tab-controls-area {
 					overflow-y: auto;
 					position: relative;
 				}
-				.beepboxEditor .instrument-settings-area > .editor-controls {
+				.beepboxEditor tab-controls-area > instrument-settings > .editor-controls {
 					position: absolute;
 					width: 100%;
 				}
@@ -243,10 +243,10 @@ export class Layout {
 					grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 					grid-template-rows: auto auto auto minmax(0, 1fr);
 					grid-template-areas:
-						"instrument-settings-area version-area"
-						"instrument-settings-area play-pause-area"
-						"instrument-settings-area menu-area"
-						"instrument-settings-area song-settings-area";
+						"tab-controls-area version-area"
+						"tab-controls-area play-pause-area"
+						"tab-controls-area menu-area"
+						"tab-controls-area song-settings-area";
 				}
 				.beepboxEditor .version-area {
 					position: sticky;
@@ -304,11 +304,11 @@ export class Layout {
 					overflow: auto;
 					max-height: 97.5vh;
 				}
-				.beepboxEditor .instrument-settings-area {
+				.beepboxEditor .tab-controls-area {
 					overflow-y: auto;
 					position: relative;
 				}
-				.beepboxEditor .instrument-settings-area > .editor-controls {
+				.beepboxEditor tab-controls-area > instrument-settings > .editor-controls {
 					position: absolute;
 					width: 100%;
 				}
@@ -321,10 +321,10 @@ export class Layout {
 					grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 					grid-template-rows: auto auto auto minmax(0, 1fr);
 					grid-template-areas:
-						"version-area instrument-settings-area"
-						"play-pause-area instrument-settings-area"
-						"menu-area instrument-settings-area"
-						"song-settings-area instrument-settings-area";
+						"version-area tab-controls-area"
+						"play-pause-area tab-controls-area"
+						"menu-area tab-controls-area"
+						"song-settings-area tab-controls-area";
 				}
 				
 				.beepboxEditor .barScrollBar {
@@ -388,11 +388,11 @@ export class Layout {
 					overflow: auto;
 					max-height: 97.5vh;
 				}
-				.beepboxEditor .instrument-settings-area {
+				.beepboxEditor .tab-controls-area {
 					overflow-y: auto;
 					position: relative;
 				}
-				.beepboxEditor .instrument-settings-area > .editor-controls {
+				.beepboxEditor tab-controls-area > instrument-settings > .editor-controls {
 					position: absolute;
 					width: 100%;
 				}
@@ -406,10 +406,10 @@ export class Layout {
 					grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 					grid-template-rows: auto auto auto minmax(0, 1fr);
 					grid-template-areas:
-						"instrument-settings-area version-area"
-						"instrument-settings-area play-pause-area"
-						"instrument-settings-area menu-area"
-						"instrument-settings-area song-settings-area";
+						"tab-controls-area version-area"
+						"tab-controls-area play-pause-area"
+						"tab-controls-area menu-area"
+						"tab-controls-area song-settings-area";
 				}				
 				.beepboxEditor .barScrollBar {
 					display: none;
@@ -473,16 +473,16 @@ export class Layout {
 					overflow: auto;
 					max-height: 97.5vh;
 				}
-				.beepboxEditor .instrument-settings-area {
+				.beepboxEditor .tab-controls-area {
 					overflow-y: auto;
 					position: relative;
 				}
-				.beepboxEditor .instrument-settings-area > .editor-controls {
+				.beepboxEditor tab-controls-area > instrument-settings > .editor-controls {
 					position: absolute;
 					width: 100%;
 				}
 				
-				.beepboxEditor .instrument-settings-area > .editor-controls {
+				.beepboxEditor tab-controls-area > instrument-settings > .editor-controls {
 					position: absolute;
 					width: 100%;
 				}
@@ -498,7 +498,7 @@ export class Layout {
 						"play-pause-area"
 						"menu-area"
 						"song-settings-area"
-						"instrument-settings-area";
+						"tab-controls-area";
 				}
 				.beepboxEditor .barScrollBar {
 					display: none;

--- a/editor/MoveNotesSidewaysPrompt.ts
+++ b/editor/MoveNotesSidewaysPrompt.ts
@@ -14,6 +14,7 @@ export class MoveNotesSidewaysPrompt implements Prompt {
 		private readonly _conversionStrategySelect: HTMLSelectElement = select({style: "width: 100%;"},
 			option({value: "overflow"}, "Overflow notes across bars."),
 			option({value: "wrapAround"}, "Wrap notes around within bars."),
+			option({value: "truncate"}, "Push notes and let them cut off."),
 	);
 		private readonly _cancelButton: HTMLButtonElement = button({class: "cancelButton"});
 		private readonly _okayButton: HTMLButtonElement = button({class: "okayButton", style: "width:45%;"}, "Okay");

--- a/editor/MuteEditor.ts
+++ b/editor/MuteEditor.ts
@@ -24,8 +24,8 @@ export class MuteEditor {
 		HTML.option({ value: "rename" }, "Rename..."),
 		HTML.option({ value: "chnUp" }, "Move Channel Up"),
 		HTML.option({ value: "chnDown" }, "Move Channel Down"),
-		HTML.option({ value: "chnMute" }, "Mute Channel"),
-		HTML.option({ value: "chnSolo" }, "Solo Channel"),
+		HTML.option({ value: "chnMute" }, "un/Mute Channel"),
+		HTML.option({ value: "chnSolo" }, "un/Solo Channel"),
 		HTML.option({ value: "chnInsert" }, "Insert Channel Below"),
 		HTML.option({ value: "chnDelete" }, "Delete This Channel"),
 	);
@@ -89,11 +89,11 @@ export class MuteEditor {
 	private _channelDropDownGetOpenedPosition = (event: MouseEvent): void => {
 
 		this._channelDropDownLastState = this._channelDropDownOpen;
-
+		
 		this._channelDropDownChannel = Math.floor(Math.min(this._buttons.length, Math.max(0, parseInt(this._channelDropDown.style.getPropertyValue("top")) / ChannelRow.patternHeight)));
 		this._doc.muteEditorChannel = this._channelDropDownChannel;
 
-		this._channelNameDisplay.style.setProperty("display", "");
+		this._channelNameDisplay.style.setProperty("display", "none");
 
 		// Check if channel is at limit, in which case another can't be inserted
 		if ((this._channelDropDownChannel < this._doc.song.pitchChannelCount && this._doc.song.pitchChannelCount == Config.pitchChannelCountMax)

--- a/editor/PatternEditor.ts
+++ b/editor/PatternEditor.ts
@@ -322,6 +322,7 @@ export class PatternEditor {
                     this._modDragPin = this._cursor.curNote.pins[pinIdx];
                     this._modDragLowerBound = Config.modulators[setting].convertRealFactor;
                     this._modDragUpperBound = Config.modulators[setting].convertRealFactor + Config.modulators[setting].maxRawVol;
+                    this._modDragUpperBound = Config.modulators[setting].convertRealFactor + this._doc.song.getVolumeCapForSetting(true, setting, this._doc.song.channels[this._doc.channel].instruments[this._doc.getCurrentInstrument(this._barOffset)].modFilterTypes[mod]);
                     this._modDragSetting = setting;
 
                     this.modDragValueLabel.style.setProperty("left", "" + this._modDragValueLabelLeft + "px");

--- a/editor/PatternEditor.ts
+++ b/editor/PatternEditor.ts
@@ -240,7 +240,7 @@ export class PatternEditor {
         this._cursor.part =
             Math.floor(
                 Math.max(0,
-                    Math.min(this._doc.song.beatsPerBar * Config.partsPerBeat - minDivision, this._cursor.exactPart)
+                    Math.min(this._doc.song.partsPerPattern - minDivision, this._cursor.exactPart)
                 )
                 / minDivision) * minDivision;
 
@@ -433,7 +433,7 @@ export class PatternEditor {
             }
             this._cursor.end = this._cursor.start + defaultLength;
             let forceStart: number = 0;
-            let forceEnd: number = this._doc.song.beatsPerBar * Config.partsPerBeat;
+            let forceEnd: number = this._doc.song.partsPerPattern;
             if (this._cursor.prevNote != null) {
                 forceStart = this._cursor.prevNote.end;
             }
@@ -631,8 +631,8 @@ export class PatternEditor {
             // note flash
             for (var i = 0; i < noteFlashElements.length; i++) {
                 var element: SVGPathElement = noteFlashElements[i];
-                const noteStart: number = Number(element.getAttribute("note-start"))/(this._doc.song.beatsPerBar * Config.partsPerBeat)
-                const noteEnd: number = Number(element.getAttribute("note-end"))/(this._doc.song.beatsPerBar * Config.partsPerBeat)
+                const noteStart: number = Number(element.getAttribute("note-start"))/(this._doc.song.partsPerPattern)
+                const noteEnd: number = Number(element.getAttribute("note-end"))/(this._doc.song.partsPerPattern)
                 if ((modPlayhead>=noteStart)&&this._doc.prefs.notesFlashWhenPlayed) {
                     const dist = noteEnd-noteStart
                     element.style.opacity = String((1-(((modPlayhead-noteStart)-(dist/2))/(dist/2))))
@@ -1749,10 +1749,10 @@ export class PatternEditor {
             const minDivision: number = this._getMinDivision();
             const currentPart: number = this._snapToMinDivision(this._mouseX / this._partWidth);
             if (this._draggingStartOfSelection) {
-                sequence.append(new ChangePatternSelection(this._doc, Math.max(0, Math.min(this._doc.song.beatsPerBar * Config.partsPerBeat, currentPart)), this._doc.selection.patternSelectionEnd));
+                sequence.append(new ChangePatternSelection(this._doc, Math.max(0, Math.min(this._doc.song.partsPerPattern, currentPart)), this._doc.selection.patternSelectionEnd));
                 this._updateSelection();
             } else if (this._draggingEndOfSelection) {
-                sequence.append(new ChangePatternSelection(this._doc, this._doc.selection.patternSelectionStart, Math.max(0, Math.min(this._doc.song.beatsPerBar * Config.partsPerBeat, currentPart))));
+                sequence.append(new ChangePatternSelection(this._doc, this._doc.selection.patternSelectionStart, Math.max(0, Math.min(this._doc.song.partsPerPattern, currentPart))));
                 this._updateSelection();
             } else if (this._draggingSelectionContents) {
                 const pattern: Pattern | null = this._doc.getCurrentPattern(this._barOffset);
@@ -1845,7 +1845,7 @@ export class PatternEditor {
                     }
 
                     let defaultLength: number = minDivision;
-                    for (let i: number = minDivision; i <= this._doc.song.beatsPerBar * Config.partsPerBeat; i += minDivision) {
+                    for (let i: number = minDivision; i <= this._doc.song.partsPerPattern; i += minDivision) {
                         if (minDivision == 1) {
                             if (i < 5) {
                                 // Allow small lengths.
@@ -1899,7 +1899,7 @@ export class PatternEditor {
                     }
                     const continuesLastPattern: boolean = (start < 0 && this._doc.channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount);
                     if (start < 0) start = 0;
-                    if (end > this._doc.song.beatsPerBar * Config.partsPerBeat) end = this._doc.song.beatsPerBar * Config.partsPerBeat;
+                    if (end > this._doc.song.partsPerPattern) end = this._doc.song.partsPerPattern;
 
                     if (start < end) {
                         sequence.append(new ChangeEnsurePatternExists(this._doc, this._doc.channel, this._doc.bar));
@@ -1943,7 +1943,7 @@ export class PatternEditor {
                     let shiftedTime: number = Math.round((this._cursor.curNote.start + shiftedPin.time + shift) / minDivision) * minDivision;
                     const continuesLastPattern: boolean = (shiftedTime < 0.0 && this._doc.channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount);
                     if (shiftedTime < 0) shiftedTime = 0;
-                    if (shiftedTime > this._doc.song.beatsPerBar * Config.partsPerBeat) shiftedTime = this._doc.song.beatsPerBar * Config.partsPerBeat;
+                    if (shiftedTime > this._doc.song.partsPerPattern) shiftedTime = this._doc.song.partsPerPattern;
 
                     if (this._pattern == null) throw new Error();
 
@@ -2014,7 +2014,7 @@ export class PatternEditor {
                     if (this._doc.song.getChannelIsMod(this._doc.channel) && this.controlMode) {
                         // Link bend to the next note over
                         if (bendPart >= this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time) {
-                            if (this._cursor.curNote.start + this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time < this._doc.song.beatsPerBar * Config.partsPerBeat) {
+                            if (this._cursor.curNote.start + this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time < this._doc.song.partsPerPattern) {
                                 for (const note of this._pattern!.notes) {
                                     if (note.start == this._cursor.curNote.start + this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time && note.pitches[0] == this._cursor.curNote.pitches[0]) {
                                         sequence.append(new ChangeSizeBend(this._doc, note, note.pins[0].time, bendSize, bendInterval, this.shiftMode));
@@ -2050,7 +2050,7 @@ export class PatternEditor {
 
                                 if (prevPattern != null && prevPattern.instruments[0] == this._pattern!.instruments[0]) {
                                     for (const note of prevPattern.notes) {
-                                        if (note.end == this._doc.song.beatsPerBar * Config.partsPerBeat && note.pitches[0] == this._cursor.curNote.pitches[0]) {
+                                        if (note.end == this._doc.song.partsPerPattern && note.pitches[0] == this._cursor.curNote.pitches[0]) {
                                             sequence.append(new ChangeSizeBend(this._doc, note, note.pins[note.pins.length - 1].time, bendSize, bendInterval, this.shiftMode));
                                         }
                                     }
@@ -2083,7 +2083,7 @@ export class PatternEditor {
                         bendEnd = currentPart;
                     }
                     if (bendEnd < 0) bendEnd = 0;
-                    if (bendEnd > this._doc.song.beatsPerBar * Config.partsPerBeat) bendEnd = this._doc.song.beatsPerBar * Config.partsPerBeat;
+                    if (bendEnd > this._doc.song.partsPerPattern) bendEnd = this._doc.song.partsPerPattern;
                     if (bendEnd > this._cursor.curNote.end) {
                         sequence.append(new ChangeNoteTruncate(this._doc, this._pattern, this._cursor.curNote.start, bendEnd, this._cursor.curNote));
                     }
@@ -2293,7 +2293,7 @@ export class PatternEditor {
 
         this._editorWidth = this.container.clientWidth;
         this._editorHeight = this.container.clientHeight;
-        this._partWidth = this._editorWidth / (this._doc.song.beatsPerBar * Config.partsPerBeat);
+        this._partWidth = this._editorWidth / (this._doc.song.partsPerPattern);
         this._octaveOffset = (this._doc.channel >= this._doc.song.pitchChannelCount) ? 0 : this._doc.song.channels[this._doc.channel].octave * Config.pitchesPerOctave;
 
         if (this._doc.song.getChannelIsNoise(this._doc.channel)) {

--- a/editor/PatternEditor.ts
+++ b/editor/PatternEditor.ts
@@ -1767,8 +1767,8 @@ export class PatternEditor {
                     const pattern: Pattern | null = this._doc.getCurrentPattern(this._barOffset);
                     if (pattern) {
                         const stretch = new ChangeStretchHorizontal(this._doc, pattern,
-                            this._selectionOriginalCoords.start, this._selectionOriginalCoords.end,
-                            this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
+                            this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd,
+                            this._selectionOriginalCoords.start, this._selectionOriginalCoords.end);
                         sequence.append(stretch);
                     }
                 }
@@ -1782,8 +1782,8 @@ export class PatternEditor {
                     const pattern: Pattern | null = this._doc.getCurrentPattern(this._barOffset);
                     if (pattern) {
                         const stretch = new ChangeStretchHorizontal(this._doc, pattern,
-                            this._selectionOriginalCoords.start, this._selectionOriginalCoords.end,
-                            this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
+                            this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd,
+                            this._selectionOriginalCoords.start, this._selectionOriginalCoords.end);
                         sequence.append(stretch);
                     }
                 }

--- a/editor/Selection.ts
+++ b/editor/Selection.ts
@@ -6,7 +6,7 @@ import { SongDocument } from "./SongDocument";
 import { ChangeGroup } from "./Change";
 import { ColorConfig } from "./ColorConfig";
 import { ChangeTrackSelection, ChangeChannelBar, ChangeAddChannel, ChangeRemoveChannel, ChangeChannelOrder, ChangeDuplicateSelectedReusedPatterns, ChangeNoteAdded, ChangeNoteTruncate, ChangePatternNumbers, ChangePatternSelection, ChangeInsertBars, ChangeDeleteBars, ChangeEnsurePatternExists, ChangeNoteLength, ChangePaste, ChangeSetPatternInstruments, ChangeViewInstrument, ChangeModChannel, ChangeModInstrument, ChangeModSetting, ChangeModFilter, ChangePatternsPerChannel, ChangePatternRhythm, ChangePatternScale, ChangeTranspose, ChangeRhythm, comparePatternNotes, unionOfUsedNotes, generateScaleMap, discardInvalidPatternInstruments, patternsContainSameInstruments } from "./changes";
-import { ChangeMergeAcross, ChangeSplitAcross, ChangeSpreadAcross, ChangeBridgeAcross, ChangeStretchHorizontal, ChangeMergeAcrossAdjacent, ChangeStretchVertical, ChangeStretchVerticalRelative, ChangeMirrorHorizontal, ChangeTapNotesAcross, ChangeStepAcross } from "./changesNoteOps";
+import { ChangeMergeAcross, ChangeSplitAcross, ChangeBridgeAcross, ChangeStretchHorizontal, ChangeMergeAcrossAdjacent, ChangeStretchVertical, ChangeStretchVerticalRelative, ChangeMirrorHorizontal, ChangeTapNotesAcross, ChangeStepAcross, ChangeSpreadVertical, ChangeSpreadAcross } from "./changesNoteOps";
 
 interface PatternCopy {
     instruments: number[];
@@ -1023,13 +1023,17 @@ export class Selection {
         this._doc.record(this._changeStretchVertical, canReplaceLastChange);
     }
 
-    /** Sums the empty space between all notes in the selection bounds and gives them an even division of that space. */
-    public noteSpreadAcross(): void {
+    /** Spread notes horizontally or vertically. */
+    public noteSpreadAcross(spreadPitch: boolean): void {
         this._changeNoteOperations = new ChangeGroup();
 
         for (const channelIndex of this._eachSelectedChannel()) {
             for (const pattern of this._eachSelectedPattern(channelIndex)) {
-                this._changeNoteOperations.append(new ChangeSpreadAcross(this._doc, pattern));
+                if (spreadPitch) {
+                    this._changeNoteOperations.append(new ChangeSpreadVertical(this._doc, pattern));
+                } else {
+                    this._changeNoteOperations.append(new ChangeSpreadAcross(this._doc, pattern));
+                }
 			}
         }
 

--- a/editor/Selection.ts
+++ b/editor/Selection.ts
@@ -967,7 +967,7 @@ export class Selection {
 
         // Instead of cuts-per-range, this makes a split every {cut} units of time.
         if (absolute && !perNote) {
-            cuts = Math.max(Math.floor((x2 - x1) / cuts), 1);
+            cuts = Math.max(Math.floor((x2 - x1) / cuts) - 1, 1);
         }
 
         for (const channelIndex of this._eachSelectedChannel()) {
@@ -977,7 +977,7 @@ export class Selection {
                     for (const note of notesCopy) {
                         const adjustedX1 = Math.max(x1 as number, note.start);
                         const adjustedX2 = Math.min(x2 as number, note.end);
-                        const adjustedCuts = absolute ? Math.max(Math.floor((adjustedX2 - adjustedX1) / cuts), 1) : cuts;
+                        const adjustedCuts = absolute ? Math.max(Math.floor((adjustedX2 - adjustedX1) / cuts) - 1, 1) : cuts;
 
                         this._changeNoteOperations.append(new ChangeSplitAcross(this._doc, pattern, adjustedCuts, adjustedX1, adjustedX2));
                     }

--- a/editor/Selection.ts
+++ b/editor/Selection.ts
@@ -986,15 +986,19 @@ export class Selection {
                     const note = pattern.notes[i];
                     if (note.end > x1 && note.start < x2) {
                         if (vol) {
-                            if (this._doc.song.getChannelIsNoise(channelIndex)) {
+                            this._changeFlatten.append(new ChangeStepAcross(this._doc, channelIndex, pattern,
+                                this.stepAcrossPresets['volume reverb'] as IStepData
+                            ))
+
+                            /*if (this._doc.song.getChannelIsNoise(channelIndex)) {
                                 this._changeFlatten.append(new ChangeStepAcross(this._doc, channelIndex, pattern,
-                                    { volAdd: { array: ['1 - 2 * num/len'], per: 'pin' } }
+                                    this.stepAcrossPresets['volume max-min'] as IStepData
                                 ))
                             } else {
                                 this._changeFlatten.append(new ChangeStepAcross(this._doc, channelIndex, pattern,
-                                    this.stepAcrossPresets["volume max"] as IStepData
+                                    this.stepAcrossPresets['volume max'] as IStepData
                                 ))
-                            }
+                            }*/
                         } else {
                             this._changeFlatten.append(new ChangeStretchVerticalRelative(
                                 this._doc, channelIndex, pattern, 0, 0, avgPitch, note.start, note.end, bounds));
@@ -1046,14 +1050,18 @@ export class Selection {
 
     // Presets for noteStepAcross.
     private stepAcrossPresets = {
-        'invert volume': { volAdd: { array: ['1 - x'], per: 'pin', type: 'cycle' }},
+        'volume invert': { volAdd: { array: ['1 - 2*x'], per: 'pin', type: 'cycle' }},
         'volume up': { volAdd: { array: [1 / Config.noteSizeMax], per: 'note', type: 'cycle' }},
         'volume down': { volAdd: { array: [-1 / Config.noteSizeMax], per: 'note', type: 'cycle' }},
         'volume max': { volAdd: { array: [1], per: 'note', type: 'cycle' }},
-        'stagger volume': { volMult: { array: [1, 0.5], per: 'note', type: 'cycle' } },
-        'volume staccato': { volMult: { array: [1, 0], per: 'time', type: 'cycle' }, insertPinsEvery: 2 },
-        'volume staccato2': { volMult: { array: [1, 0], per: 'time', type: 'cycle' }, insertPinsEvery: 1 },
-        'volume interrupt': { volMult: { array: ['round(random() * 10) === 0 ? 0 : 1'], per: 'time', type: 'cycle' } },
+        'volume max-min': { volAdd: { array: [1, 0], per: 'note' } },
+        'volume staccato': { volMult: { array: [1, 0.5], per: 'time', type: 'cycle' }, insertPinsEvery: 2 },
+        'volume staccato2': { volMult: { array: [1, 0.5], per: 'time', type: 'cycle' }, insertPinsEvery: 1 },
+        'volume wave': { volMult: { array: ['(sin(pi/16 * num) + 1) / 2'], per: 'time' }, insertPinsEvery: 1 },
+        'volume wave2': { volMult: { array: ['(sin(pi/8 * num) + 1) / 2'], per: 'time' }, insertPinsEvery: 1 },
+        'volume wave3': { volMult: { array: ['(sin(pi/4 * num) + 1) / 2'], per: 'time' }, insertPinsEvery: 1 },
+        'volume reverb': { volMult: { array: ['1 + ((x % i) '], per: 'pin' }, type: 'cycle', insertPinsEvery: 2 },
+        'volume interrupt': { volMult: { array: ['floor(random() * 1.5 + 0.5) === 0 ? 0 : 1'], per: 'time' }, insertPinsEvery: 1 },
         'fade in': { volMult: { array: [0, 1], per: 'time', type: 'normal' } },
         'fade out': { volMult: { array: [1, 0], per: 'time', type: 'normal' } },
     }

--- a/editor/SongDocument.ts
+++ b/editor/SongDocument.ts
@@ -12,6 +12,7 @@ import { Preferences } from "./Preferences";
 import { Change } from "./Change";
 import { ChangeNotifier } from "./ChangeNotifier";
 import { ChangeSong, setDefaultInstruments, discardInvalidPatternInstruments, ChangeHoldingModRecording} from "./changes";
+import { TabControl, TabControls, TabSettingType } from "./TabControls"
 
 interface HistoryState {
 	canUndo: boolean;
@@ -37,6 +38,7 @@ export class SongDocument {
 	public bar: number = 0;
 	public recalcChannelNames: boolean;
 	public recentPatternInstruments: number[][] = [];
+	public viewedTab: TabControl = TabControls[TabSettingType.EditInstrument];
 	public viewedInstrument: number[] = [];
 	public recordingModulators: boolean = false;
 	public continuingModRecordingChange: ChangeHoldingModRecording | null = null;

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -4396,9 +4396,9 @@ export class SongEditor {
                 break;
             case 37: // left
                 if (event.shiftKey) {
-                    this._doc.selection.boxSelectionX1 = Math.max(0, this._doc.selection.boxSelectionX1 - 1);
-                    this._doc.selection.scrollToEndOfSelection();
-                    this._doc.selection.selectionUpdated();
+                        this._doc.selection.boxSelectionX1 = Math.max(0, this._doc.selection.boxSelectionX1 - 1);
+                        this._doc.selection.scrollToEndOfSelection();
+                        this._doc.selection.selectionUpdated();
                 } else {
                     this._doc.selection.setChannelBar(this._doc.channel, (this._doc.bar + this._doc.song.barCount - 1) % this._doc.song.barCount);
                     this._doc.selection.resetBoxSelection();
@@ -4407,9 +4407,9 @@ export class SongEditor {
                 break;
             case 39: // right
                 if (event.shiftKey) {
-                    this._doc.selection.boxSelectionX1 = Math.min(this._doc.song.barCount - 1, this._doc.selection.boxSelectionX1 + 1);
-                    this._doc.selection.scrollToEndOfSelection();
-                    this._doc.selection.selectionUpdated();
+                        this._doc.selection.boxSelectionX1 = Math.min(this._doc.song.barCount - 1, this._doc.selection.boxSelectionX1 + 1);
+                        this._doc.selection.scrollToEndOfSelection();
+                        this._doc.selection.selectionUpdated();
                 } else {
                     this._doc.selection.setChannelBar(this._doc.channel, (this._doc.bar + 1) % this._doc.song.barCount);
                     this._doc.selection.resetBoxSelection();
@@ -5113,28 +5113,28 @@ export class SongEditor {
                 this._doc.selection.transpose(false, false);
                 break;
             case "noteOpMerge":
-                this._doc.selection.noteOpMerge();
+                this._doc.selection.noteMerge(true);
                 break;
             case "noteOpBridge":
-                this._doc.selection.noteOpBridge(false);
+                this._doc.selection.noteBridge(true, true);
                 break;
             case "noteOpSeparate":
-                this._doc.selection.noteOpSeparate(5, this._doc.selection.boxSelectionActive ? this._doc.selection.patternSelectionStart : undefined);
+                this._doc.selection.noteSegmentizeAcross(2, false, true);
                 break;
             case "noteOpPartition":
-                this._doc.selection.noteOpPartition();
+                this._doc.selection.noteDivideSelfAcross();
                 break;
             case "flattenNotes":
-                this._doc.selection.flattenNotes();
+                this._doc.selection.noteFlattenAcross();
                 break;
             case "stretchNotes":
-                this._doc.selection.stretchNotes(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd, 0, this._doc.song.beatsPerBar * Config.partsPerBeat);
+                this._doc.selection.noteStretchAcross(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd, 0, this._doc.song.beatsPerBar * Config.partsPerBeat);
                 break;
             case "noteOpMirrorHorizontal":
-                this._doc.selection.mirrorNotes(false);
+                this._doc.selection.noteMirrorAcross(false);
                 break;
             case "noteOpMirrorVertical":
-                this._doc.selection.mirrorNotes(true);
+                this._doc.selection.noteMirrorAcross(true);
                 break;
             case "selectAll":
                 this._doc.selection.selectAll();

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -794,7 +794,8 @@ export class SongEditor {
         option({ value: "noteOpBridge" }, "Bridge Between Notes"),
         option({ value: "noteOpSeparate" }, "Separate Notes"),
         option({ value: "noteOpPartition" }, "Divide Evenly Within Notes"),
-        option({ value: "noteOpFlatten" }, "Flatten Notes"),
+        option({ value: "flattenNotes" }, "Flatten Notes"),
+        option({ value: "stretchNotes" }, "Stretch Notes"),
         option({ value: "noteOpMirrorHorizontal" }, "Mirror Notes Horz"),
         option({ value: "noteOpMirrorVertical" }, "Mirror Notes Vert"),
         option({ value: "moveNotesSideways" }, "Move All Notes Sideways... (W)"),
@@ -5118,13 +5119,16 @@ export class SongEditor {
                 this._doc.selection.noteOpBridge(false);
                 break;
             case "noteOpSeparate":
-                this._doc.selection.noteOpSeparate(1, this._doc.selection.boxSelectionActive ? this._doc.selection.patternSelectionStart : undefined);
+                this._doc.selection.noteOpSeparate(5, this._doc.selection.boxSelectionActive ? this._doc.selection.patternSelectionStart : undefined);
                 break;
             case "noteOpPartition":
                 this._doc.selection.noteOpPartition();
                 break;
-            case "noteOpFlatten":
+            case "flattenNotes":
                 this._doc.selection.flattenNotes();
+                break;
+            case "stretchNotes":
+                this._doc.selection.stretchNotes(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd, 0, this._doc.song.beatsPerBar * Config.partsPerBeat);
                 break;
             case "noteOpMirrorHorizontal":
                 this._doc.selection.mirrorNotes(false);

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -790,6 +790,13 @@ export class SongEditor {
         option({ value: "duplicatePatterns" }, "Duplicate Reused Patterns (D)"),
         option({ value: "transposeUp" }, "Move Notes Up (+ or ⇧+)"),
         option({ value: "transposeDown" }, "Move Notes Down (- or ⇧-)"),
+        option({ value: "noteOpMerge" }, "Merge Notes"),
+        option({ value: "noteOpBridge" }, "Bridge Between Notes"),
+        option({ value: "noteOpSeparate" }, "Separate Notes"),
+        option({ value: "noteOpPartition" }, "Divide Evenly Within Notes"),
+        option({ value: "noteOpFlatten" }, "Flatten Notes"),
+        option({ value: "noteOpMirrorHorizontal" }, "Mirror Notes Horz"),
+        option({ value: "noteOpMirrorVertical" }, "Mirror Notes Vert"),
         option({ value: "moveNotesSideways" }, "Move All Notes Sideways... (W)"),
 	    option({ value: "generateEuclideanRhythm" }, "Generate Euclidean Rhythm... (E)"),
         option({ value: "beatsPerBar" }, "Change Beats Per Bar... (⇧B)"),
@@ -5103,6 +5110,27 @@ export class SongEditor {
                 break;
             case "transposeDown":
                 this._doc.selection.transpose(false, false);
+                break;
+            case "noteOpMerge":
+                this._doc.selection.noteOpMerge();
+                break;
+            case "noteOpBridge":
+                this._doc.selection.noteOpBridge(false);
+                break;
+            case "noteOpSeparate":
+                this._doc.selection.noteOpSeparate(1, this._doc.selection.boxSelectionActive ? this._doc.selection.patternSelectionStart : undefined);
+                break;
+            case "noteOpPartition":
+                this._doc.selection.noteOpPartition();
+                break;
+            case "noteOpFlatten":
+                this._doc.selection.flattenNotes();
+                break;
+            case "noteOpMirrorHorizontal":
+                this._doc.selection.mirrorNotes(false);
+                break;
+            case "noteOpMirrorVertical":
+                this._doc.selection.mirrorNotes(true);
                 break;
             case "selectAll":
                 this._doc.selection.selectAll();

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -46,7 +46,7 @@ import { SpectrumEditor, SpectrumEditorPrompt } from "./SpectrumEditor";
 import { CustomThemePrompt } from "./CustomThemePrompt";
 import { ThemePrompt } from "./ThemePrompt";
 import { TipPrompt } from "./TipPrompt";
-import { ChangeTempo, ChangeKeyOctave, ChangeChorus, ChangeEchoDelay, ChangeEchoSustain, ChangeReverb, ChangeVolume, ChangePan, ChangePatternSelection, ChangePatternsPerChannel, ChangePatternNumbers, ChangeSupersawDynamism, ChangeSupersawSpread, ChangeSupersawShape, ChangePulseWidth, ChangeFeedbackAmplitude, ChangeOperatorAmplitude, ChangeOperatorFrequency, ChangeDrumsetEnvelope, ChangePasteInstrument, ChangePreset, pickRandomPresetValue, ChangeRandomGeneratedInstrument, ChangeEQFilterType, ChangeNoteFilterType, ChangeEQFilterSimpleCut, ChangeEQFilterSimplePeak, ChangeNoteFilterSimpleCut, ChangeNoteFilterSimplePeak, ChangeScale, ChangeDetectKey, ChangeKey, ChangeRhythm, ChangeFeedbackType, ChangeAlgorithm, ChangeChipWave, ChangeNoiseWave, ChangeTransition, ChangeToggleEffects, ChangeVibrato, ChangeUnison, ChangeChord, ChangeSong, ChangePitchShift, ChangeDetune, ChangeDistortion, ChangeStringSustain, ChangeBitcrusherFreq, ChangeBitcrusherQuantization, ChangeAddEnvelope, ChangeEnvelopeSpeed, ChangeDiscreteEnvelope, ChangeAddChannelInstrument, ChangeRemoveChannelInstrument, ChangeCustomWave, ChangeOperatorWaveform, ChangeOperatorPulseWidth, ChangeSongTitle, ChangeVibratoDepth, ChangeVibratoSpeed, ChangeVibratoDelay, ChangeVibratoType, ChangePanDelay, ChangeArpeggioSpeed, ChangeFastTwoNoteArp, ChangeClicklessTransition, ChangeAliasing, ChangeSetPatternInstruments, ChangeHoldingModRecording, ChangeChipWavePlayBackwards, ChangeChipWaveStartOffset, ChangeChipWaveLoopEnd, ChangeChipWaveLoopStart, ChangeChipWaveLoopMode, ChangeChipWaveUseAdvancedLoopControls, ChangeDecimalOffset, ChangeUnisonVoices, ChangeUnisonSpread, ChangeUnisonOffset, ChangeUnisonExpression, ChangeUnisonSign, Change6OpFeedbackType, Change6OpAlgorithm, ChangeCustomAlgorythmorFeedback } from "./changes";
+import { ChangeTempo, ChangeKeyOctave, ChangeChorus, ChangeEchoDelay, ChangeEchoSustain, ChangeReverb, ChangeVolume, ChangePan, ChangePatternSelection, ChangePatternsPerChannel, ChangePatternNumbers, ChangeSupersawDynamism, ChangeSupersawSpread, ChangeSupersawShape, ChangePulseWidth, ChangeFeedbackAmplitude, ChangeOperatorAmplitude, ChangeOperatorFrequency, ChangeDrumsetEnvelope, ChangePasteInstrument, ChangePreset, pickRandomPresetValue, ChangeRandomGeneratedInstrument, ChangeEQFilterType, ChangeNoteFilterType, ChangeEQFilterSimpleCut, ChangeEQFilterSimplePeak, ChangeNoteFilterSimpleCut, ChangeNoteFilterSimplePeak, ChangeScale, ChangeDetectKey, ChangeKey, ChangeRhythm, ChangeFeedbackType, ChangeAlgorithm, ChangeChipWave, ChangeNoiseWave, ChangeTransition, ChangeToggleEffects, ChangeVibrato, ChangeUnison, ChangeChord, ChangeSong, ChangePitchShift, ChangeDetune, ChangeDistortion, ChangeStringSustain, ChangeBitcrusherFreq, ChangeBitcrusherQuantization, ChangeAddEnvelope, ChangeEnvelopeSpeed, ChangeDiscreteEnvelope, ChangeAddChannelInstrument, ChangeRemoveChannelInstrument, ChangeCustomWave, ChangeOperatorWaveform, ChangeOperatorPulseWidth, ChangeSongTitle, ChangeVibratoDepth, ChangeVibratoSpeed, ChangeVibratoDelay, ChangeVibratoType, ChangePanDelay, ChangeArpeggioSpeed, ChangeFastTwoNoteArp, ChangeClicklessTransition, ChangeAliasing, ChangeSetPatternInstruments, ChangeHoldingModRecording, ChangeChipWavePlayBackwards, ChangeChipWaveStartOffset, ChangeChipWaveLoopEnd, ChangeChipWaveLoopStart, ChangeChipWaveLoopMode, ChangeChipWaveUseAdvancedLoopControls, ChangeDecimalOffset, ChangeUnisonVoices, ChangeUnisonSpread, ChangeUnisonOffset, ChangeUnisonExpression, ChangeUnisonSign, Change6OpFeedbackType, Change6OpAlgorithm, ChangeCustomAlgorythmorFeedback, ChangeViewedTab } from "./changes";
 
 import { TrackEditor } from "./TrackEditor";
 import { oscilloscopeCanvas } from "../global/Oscilloscope";
@@ -54,6 +54,7 @@ import { VisualLoopControlsPrompt } from "./VisualLoopControlsPrompt";
 import { SampleLoadingStatusPrompt } from "./SampleLoadingStatusPrompt";
 import { AddSamplesPrompt } from "./AddSamplesPrompt";
 import { ShortenerConfigPrompt } from "./ShortenerConfigPrompt";
+import { TabControls, TabSettingType as TabSettingType } from "./TabControls";
 
 const { button, div, input, select, span, optgroup, option, canvas } = HTML;
 
@@ -849,6 +850,13 @@ export class SongEditor {
     private readonly _drumPresetSelect: HTMLSelectElement = buildPresetOptions(true, "drumPresetSelect");
     private readonly _algorithmSelect: HTMLSelectElement = buildOptions(select(), Config.algorithms.map(algorithm => algorithm.name));
     private readonly _algorithmSelectRow: HTMLDivElement = div({ class: "selectRow" }, span({ class: "tip", onclick: () => this._openPrompt("algorithm") }, "Algorithm: "), div({ class: "selectContainer" }, this._algorithmSelect));
+    private readonly _tabButtonInstrument: HTMLInputElement = input({ type: "radio", name: 'tab-settings-radio-group', class: "tab-settings-radio" });
+    private readonly _tabBtnInstrLabel: HTMLDivElement = div({ class: "tab-settings-radio selected-tab" }, TabControls[TabSettingType.EditInstrument].icon);
+    private readonly _tabRadioDivInstr: HTMLDivElement = div({ class: "tab-settings-radiodiv" }, this._tabButtonInstrument, this._tabBtnInstrLabel);
+    private readonly _tabButtonSelection: HTMLInputElement = input({ type: "radio", name: 'tab-settings-radio-group', class: "tab-settings-radio" });
+    private readonly _tabBtnSelLabel: HTMLDivElement = div({ class: "tab-settings-radio" }, TabControls[TabSettingType.EditSelection].icon);
+    private readonly _tabRadioDivSel: HTMLDivElement = div({ class: "tab-settings-radiodiv" }, this._tabButtonSelection, this._tabBtnSelLabel);
+    private readonly _tabSettingsButtonsGroup: HTMLDivElement = div({ class: "tab-settings-buttons-group" }, this._tabRadioDivInstr, this._tabRadioDivSel);
     private readonly _instrumentButtons: HTMLButtonElement[] = [];
     private readonly _instrumentAddButton: HTMLButtonElement = button({ type: "button", class: "add-instrument last-button" });
     private readonly _instrumentRemoveButton: HTMLButtonElement = button({ type: "button", class: "remove-instrument" });
@@ -1329,9 +1337,13 @@ export class SongEditor {
             this._sampleLoadingStatusContainer,
         ),
     );
-    private readonly _instrumentSettingsArea: HTMLDivElement = div({ class: "instrument-settings-area" },
+    private readonly instrumentAndModulatorSettings: HTMLDivElement = div({ class: "instrument-settings" },
         this._instrumentSettingsGroup,
         this._modulatorGroup);
+    private readonly _tabSettingsArea: HTMLDivElement = div({ class: 'tab-controls-area' },
+        this._tabSettingsButtonsGroup,
+        this.instrumentAndModulatorSettings
+    );
     public readonly _settingsArea: HTMLDivElement = div({ class: "settings-area noSelection" },
         div({ class: "version-area" },
             div({ style: `text-align: center; margin: 3px 0; color: ${ColorConfig.secondaryText};` },
@@ -1356,7 +1368,7 @@ export class SongEditor {
         ),
         this._menuArea,
         this._songSettingsArea,
-        this._instrumentSettingsArea,
+        this._tabSettingsArea,
     );
 
     public readonly mainLayer: HTMLDivElement = div({ class: "beepboxEditor", tabIndex: "0" },
@@ -1577,6 +1589,8 @@ export class SongEditor {
         //this._pitchedPresetSelect.addEventListener("change", this._whenSetPitchedPreset);
         //this._drumPresetSelect.addEventListener("change", this._whenSetDrumPreset);
         this._algorithmSelect.addEventListener("change", this._whenSetAlgorithm);
+        this._tabButtonInstrument.addEventListener("change", () => this._whenSelectTab(TabSettingType.EditInstrument));
+        this._tabButtonSelection.addEventListener("change", () => this._whenSelectTab(TabSettingType.EditSelection));
         this._instrumentsButtonBar.addEventListener("click", this._whenSelectInstrument);
         //this._customizeInstrumentButton.addEventListener("click", this._whenCustomizePressed);
         this._feedbackTypeSelect.addEventListener("change", this._whenSetFeedbackType);
@@ -2193,7 +2207,8 @@ export class SongEditor {
         this._sampleLoadingStatusContainer.style.display = this._doc.prefs.showSampleLoadingStatus ? "" : "none";
         this._instrumentCopyGroup.style.display = this._doc.prefs.instrumentCopyPaste ? "" : "none";
         this._instrumentExportGroup.style.display = this._doc.prefs.instrumentImportExport ? "" : "none";
-        this._instrumentSettingsArea.style.scrollbarWidth = this._doc.prefs.showInstrumentScrollbars ? "" : "none";
+        this.instrumentAndModulatorSettings.style.display = this._doc.viewedTab == TabControls[TabSettingType.EditInstrument] ? "" : "none";
+        this.instrumentAndModulatorSettings.style.scrollbarWidth = this._doc.prefs.showInstrumentScrollbars ? "" : "none";
         if (document.getElementById('text-content'))
             document.getElementById('text-content')!.style.display = this._doc.prefs.showDescription ? "" : "none";
 
@@ -3454,14 +3469,14 @@ export class SongEditor {
         // auto-scroll the settings areas to ensure the new settings are visible.
         if (this._doc.addedEffect) {
             const envButtonRect: DOMRect = this._addEnvelopeButton.getBoundingClientRect();
-            const instSettingsRect: DOMRect = this._instrumentSettingsArea.getBoundingClientRect();
+            const instSettingsRect: DOMRect = this.instrumentAndModulatorSettings.getBoundingClientRect();
             const settingsRect: DOMRect = this._settingsArea.getBoundingClientRect();
-            this._instrumentSettingsArea.scrollTop += Math.max(0, envButtonRect.top - (instSettingsRect.top + instSettingsRect.height));
+            this.instrumentAndModulatorSettings.scrollTop += Math.max(0, envButtonRect.top - (instSettingsRect.top + instSettingsRect.height));
             this._settingsArea.scrollTop += Math.max(0, envButtonRect.top - (settingsRect.top + settingsRect.height));
             this._doc.addedEffect = false;
         }
         if (this._doc.addedEnvelope) {
-            this._instrumentSettingsArea.scrollTop = this._instrumentSettingsArea.scrollHeight;
+            this.instrumentAndModulatorSettings.scrollTop = this.instrumentAndModulatorSettings.scrollHeight;
             this._settingsArea.scrollTop = this._settingsArea.scrollHeight;
             this._doc.addedEnvelope = false;
         }
@@ -3492,6 +3507,10 @@ export class SongEditor {
     }
 
     private _renderInstrumentBar(channel: Channel, instrumentIndex: number, colors: ChannelColors) {
+        if (this._doc.viewedTab !== TabControls[TabSettingType.EditInstrument]) {
+            return;
+        }
+
         if (this._doc.song.layeredInstruments || this._doc.song.patternInstruments) {
             this._instrumentsButtonRow.style.display = "";
             this._instrumentsButtonBar.style.setProperty("--text-color-lit", colors.primaryNote);
@@ -3595,8 +3614,8 @@ export class SongEditor {
             this._octaveScrollBar.container.style.opacity = "";
             this._trackContainer.style.pointerEvents = "";
             this._loopEditor.container.style.opacity = "";
-            this._instrumentSettingsArea.style.pointerEvents = "";
-            this._instrumentSettingsArea.style.opacity = "";
+            this._tabSettingsArea.style.pointerEvents = "";
+            this._tabSettingsArea.style.opacity = "";
             this._menuArea.style.pointerEvents = "";
             this._menuArea.style.opacity = "";
             this._songSettingsArea.style.pointerEvents = "";
@@ -3611,8 +3630,8 @@ export class SongEditor {
                 this._octaveScrollBar.container.style.opacity = "0.5";
                 this._trackContainer.style.pointerEvents = "none";
                 this._loopEditor.container.style.opacity = "0.5";
-                this._instrumentSettingsArea.style.pointerEvents = "none";
-                this._instrumentSettingsArea.style.opacity = "0.5";
+                this._tabSettingsArea.style.pointerEvents = "none";
+                this._tabSettingsArea.style.opacity = "0.5";
                 this._menuArea.style.pointerEvents = "none";
                 this._menuArea.style.opacity = "0.5";
                 this._songSettingsArea.style.pointerEvents = "none";
@@ -4792,6 +4811,21 @@ export class SongEditor {
         this._doc.record(new Change6OpAlgorithm(this._doc, this._algorithm6OpSelect.selectedIndex));
         this._customAlgorithmCanvas.reset()
     }
+
+    private _whenSelectTab = (type: TabSettingType): void => {
+        [
+            {type: TabSettingType.EditInstrument, obj: this._tabBtnInstrLabel},
+            {type: TabSettingType.EditSelection, obj: this._tabBtnSelLabel}
+        ].forEach((entry) => {
+            if (type == entry.type) {
+                if (!entry.obj.classList.contains('selected-tab')) { entry.obj.classList.add('selected-tab') }
+            } else {
+                entry.obj.classList.remove('selected-tab')
+            }
+        })
+
+        this._doc.record(new ChangeViewedTab(this._doc, type))
+    }
     
     private _whenSelectInstrument = (event: MouseEvent): void => {
         if (event.target == this._instrumentAddButton) {
@@ -4807,7 +4841,7 @@ export class SongEditor {
             if (this._doc.channel >= this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount) {
                 this._piano.forceRender();
             }
-		this._renderInstrumentBar(this._doc.song.channels[this._doc.channel], index, ColorConfig.getChannelColor(this._doc.song, this._doc.channel));
+            this._renderInstrumentBar(this._doc.song.channels[this._doc.channel], index, ColorConfig.getChannelColor(this._doc.song, this._doc.channel));
         }
 
         this.refocusStage();

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -792,12 +792,14 @@ export class SongEditor {
         option({ value: "transposeDown" }, "Move Notes Down (- or ⇧-)"),
         option({ value: "noteOpMerge" }, "Merge Notes"),
         option({ value: "noteOpBridge" }, "Bridge Between Notes"),
-        option({ value: "noteOpSeparate" }, "Separate Notes"),
-        option({ value: "noteOpPartition" }, "Divide Evenly Within Notes"),
+        option({ value: "noteOpSegmentize" }, "Segmentize Notes"),
         option({ value: "flattenNotes" }, "Flatten Notes"),
-        option({ value: "stretchNotes" }, "Stretch Notes"),
+        option({ value: "stretchNotes" }, "Stretch Notes Horz"),
+        option({ value: "stretchNotesVertical" }, "Stretch Notes Vert"),
         option({ value: "noteOpMirrorHorizontal" }, "Mirror Notes Horz"),
         option({ value: "noteOpMirrorVertical" }, "Mirror Notes Vert"),
+        option({ value: "spreadAcross" }, "Spread Notes Evenly"),
+        option({ value: "stutterNotes"}, "Stutter Notes"),
         option({ value: "moveNotesSideways" }, "Move All Notes Sideways... (W)"),
 	    option({ value: "generateEuclideanRhythm" }, "Generate Euclidean Rhythm... (E)"),
         option({ value: "beatsPerBar" }, "Change Beats Per Bar... (⇧B)"),
@@ -5118,23 +5120,29 @@ export class SongEditor {
             case "noteOpBridge":
                 this._doc.selection.noteBridge(true, true);
                 break;
-            case "noteOpSeparate":
+            case "noteOpSegmentize":
                 this._doc.selection.noteSegmentizeAcross(2, false, true);
-                break;
-            case "noteOpPartition":
-                this._doc.selection.noteDivideSelfAcross();
                 break;
             case "flattenNotes":
                 this._doc.selection.noteFlattenAcross();
                 break;
             case "stretchNotes":
-                this._doc.selection.noteStretchAcross(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd, 0, this._doc.song.beatsPerBar * Config.partsPerBeat);
+                this._doc.selection.noteStretchHorizontal(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
+                break;
+            case "stretchNotesVertical":
+                this._doc.selection.noteStretchVertical(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
                 break;
             case "noteOpMirrorHorizontal":
                 this._doc.selection.noteMirrorAcross(false);
                 break;
             case "noteOpMirrorVertical":
                 this._doc.selection.noteMirrorAcross(true);
+                break;
+            case "spreadAcross":
+                this._doc.selection.noteSpreadAcross();
+                break;
+            case "stutterNotes":
+                this._doc.selection.noteStutterAcross();
                 break;
             case "selectAll":
                 this._doc.selection.selectAll();

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -34,7 +34,7 @@ import { MuteEditor } from "./MuteEditor";
 import { OctaveScrollBar } from "./OctaveScrollBar";
 import { MidiInputHandler } from "./MidiInput";
 import { KeyboardLayout } from "./KeyboardLayout";
-import { PatternEditor } from "./PatternEditor";
+import { PatternEditor, SelectionMode } from "./PatternEditor";
 import { Piano } from "./Piano";
 import { Prompt } from "./Prompt";
 import { SongDocument } from "./SongDocument";
@@ -56,7 +56,7 @@ import { AddSamplesPrompt } from "./AddSamplesPrompt";
 import { ShortenerConfigPrompt } from "./ShortenerConfigPrompt";
 import { TabControls, TabSettingType as TabSettingType } from "./TabControls";
 
-const { button, div, input, select, span, optgroup, option, canvas } = HTML;
+const { button, div, label, input, select, span, optgroup, option, canvas } = HTML;
 
 function buildOptions(menu: HTMLSelectElement, items: ReadonlyArray<string | number>): HTMLSelectElement {
     for (let index: number = 0; index < items.length; index++) {
@@ -790,15 +790,8 @@ export class SongEditor {
         option({ value: "duplicatePatterns" }, "Duplicate Reused Patterns (D)"),
         option({ value: "transposeUp" }, "Move Notes Up (+ or ⇧+)"),
         option({ value: "transposeDown" }, "Move Notes Down (- or ⇧-)"),
-        option({ value: "noteOpMerge" }, "Merge Notes"),
-        option({ value: "noteOpBridge" }, "Bridge Between Notes"),
-        option({ value: "noteOpSegmentize" }, "Segmentize Notes"),
-        option({ value: "flattenNotes" }, "Flatten Notes"),
         option({ value: "stretchNotes" }, "Stretch Notes Horz"),
         option({ value: "stretchNotesVertical" }, "Stretch Notes Vert"),
-        option({ value: "noteOpMirrorHorizontal" }, "Mirror Notes Horz"),
-        option({ value: "noteOpMirrorVertical" }, "Mirror Notes Vert"),
-        option({ value: "spreadAcross" }, "Spread Notes Evenly"),
         option({ value: "stutterNotes"}, "Stutter Notes"),
         option({ value: "moveNotesSideways" }, "Move All Notes Sideways... (W)"),
 	    option({ value: "generateEuclideanRhythm" }, "Generate Euclidean Rhythm... (E)"),
@@ -860,13 +853,15 @@ export class SongEditor {
     private readonly _drumPresetSelect: HTMLSelectElement = buildPresetOptions(true, "drumPresetSelect");
     private readonly _algorithmSelect: HTMLSelectElement = buildOptions(select(), Config.algorithms.map(algorithm => algorithm.name));
     private readonly _algorithmSelectRow: HTMLDivElement = div({ class: "selectRow" }, span({ class: "tip", onclick: () => this._openPrompt("algorithm") }, "Algorithm: "), div({ class: "selectContainer" }, this._algorithmSelect));
+
     private readonly _tabButtonInstrument: HTMLInputElement = input({ type: "radio", name: 'tab-settings-radio-group', class: "tab-settings-radio" });
     private readonly _tabBtnInstrLabel: HTMLDivElement = div({ class: "tab-settings-radio selected-tab" }, TabControls[TabSettingType.EditInstrument].icon);
-    private readonly _tabRadioDivInstr: HTMLDivElement = div({ class: "tab-settings-radiodiv" }, this._tabButtonInstrument, this._tabBtnInstrLabel);
     private readonly _tabButtonSelection: HTMLInputElement = input({ type: "radio", name: 'tab-settings-radio-group', class: "tab-settings-radio" });
     private readonly _tabBtnSelLabel: HTMLDivElement = div({ class: "tab-settings-radio" }, TabControls[TabSettingType.EditSelection].icon);
-    private readonly _tabRadioDivSel: HTMLDivElement = div({ class: "tab-settings-radiodiv" }, this._tabButtonSelection, this._tabBtnSelLabel);
-    private readonly _tabSettingsButtonsGroup: HTMLDivElement = div({ class: "tab-settings-buttons-group" }, this._tabRadioDivInstr, this._tabRadioDivSel);
+    private readonly _tabSettingsButtonsGroup: HTMLDivElement = div({ class: "tab-settings-buttons-group" },
+        div({ class: "tab-settings-radiodiv" }, this._tabButtonInstrument, this._tabBtnInstrLabel),
+        div({ class: "tab-settings-radiodiv" }, this._tabButtonSelection, this._tabBtnSelLabel));
+
     private readonly _instrumentButtons: HTMLButtonElement[] = [];
     private readonly _instrumentAddButton: HTMLButtonElement = button({ type: "button", class: "add-instrument last-button" });
     private readonly _instrumentRemoveButton: HTMLButtonElement = button({ type: "button", class: "remove-instrument" });
@@ -1347,13 +1342,87 @@ export class SongEditor {
             this._sampleLoadingStatusContainer,
         ),
     );
-    private readonly instrumentAndModulatorSettings: HTMLDivElement = div({ class: "instrument-settings" },
+
+    private readonly _selectionOpsDescription = div({ style: `padding: 3px 0; max-width: 15em; text-align: center; color: ${ColorConfig.secondaryText};` }, "Selection");
+    private readonly _selectionModeLabel = div({ style: `padding: 3px 0; color: ${ColorConfig.secondaryText};` }, "Move mode");
+    private readonly _selectionModeBtnMove = input({ type: "radio", name: "selection-mode-radio-group", class: "tab-settings-radio" });
+    private readonly _selectionModeMoveLabel = div({ class: "tab-settings-radio selected-tab" }, "↤");
+    private readonly _selectionModeBtnStretch = input({ type: "radio", name: "selection-mode-radio-group", class: "tab-settings-radio" });
+    private readonly _selectionModeStretchLabel = div({ class: "tab-settings-radio" }, "↔");
+    private readonly _selectionModeButtonsGroup: HTMLDivElement = div({ class: "tab-settings-buttons-group" },
+        div({ class: "tab-settings-radiodiv" }, this._selectionModeBtnMove, this._selectionModeMoveLabel),
+        div({ class: "tab-settings-radiodiv" }, this._selectionModeBtnStretch, this._selectionModeStretchLabel)
+    );
+    private readonly _selectionOpsMerge = button({ class: "selectionOps-actionbutton noteOpMerge" });
+    private readonly _selectionOpsMergeAll = input({ type: "checkbox", class: "selectionOps-checkbox"});
+    private readonly _selectionOpsBridge = button({ class: "selectionOps-actionbutton noteOpBridge" });
+    private readonly _selectionOpsBridgeBend = input({ type: "checkbox", class: "selectionOps-checkbox"});
+    private readonly _selectionOpsSpread = button({ class: "selectionOps-actionbutton noteOpSpread" });
+    private readonly _selectionOpsMirrorHorz = button({ class: "selectionOps-actionbutton noteOpMirror" });
+    private readonly _selectionOpsMirrorVert = button({ class: "selectionOps-actionbutton noteOpMirror", style: 'transform: rotate(90deg);' });
+    private readonly _selectionOpsFlatten = button({ class: "selectionOps-actionbutton noteOpFlatten" });
+    private readonly _selectionOpsFlattenAcross = input({ type: "checkbox", class: "selectionOps-checkbox"});
+    private readonly _selectionOpsSplit = button({ class: "selectionOps-actionbutton noteOpSplit" });
+    private readonly _selectionOpsSplitLabel = div({ class: "tip", onclick: () => this._openPrompt("selectionSplit") }, "");
+    private readonly _selectionOpsSplitSlider = new Slider(
+        input({ title: "cuts", style: "width: 6rem; flex-grow: 1; margin-left: 0.5rem;", type: "range", min: "1", max: String(Math.floor(this._doc.song.partsPerPattern / 2)), value: "1", step: "1" }), this._doc, null, false);
+    private readonly _selectionOpsSplitAcross = input({ type: "checkbox", class: "selectionOps-checkbox"});
+    private readonly _selectionOpsSplitAbsolute = input({ type: "checkbox", class: "selectionOps-checkbox"});
+    private readonly _selectionOpsRow1 = div({ class: "selectionOps-row"},
+        div({ class: "selectionOps-action"},
+            div({ class: "tip", onclick: () => this._openPrompt("selectionMerge") }, "Merge"),
+            div({ class: "selectionOps-action-controls"},
+                this._selectionOpsMerge,
+                label({ class: "checkbox-container" }, this._selectionOpsMergeAll, "All"))),
+        div({ class: "selectionOps-action"},
+            div({ class: "tip", onclick: () => this._openPrompt("selectionBridge") }, "Bridge"),
+            div({ class: "selectionOps-action-controls"},
+                this._selectionOpsBridge,
+                label({ class: "checkbox-container" }, this._selectionOpsBridgeBend, "Bend"))),
+        div({ class: "selectionOps-action"},
+            div({ class: "tip", onclick: () => this._openPrompt("selectionSpread") }, "Spread"),
+            div({ class: "selectionOps-action-controls"},
+                this._selectionOpsSpread))
+    );
+    private readonly _selectionOpsRow2 = div({ class: "selectionOps-row"},
+        div({ class: "selectionOps-action"},
+            div({ class: "tip", onclick: () => this._openPrompt("selectionMirror") }, "Mirror"),
+            div({ class: "selectionOps-row-inside"},
+                div({ class: "selectionOps-action-controls"}, this._selectionOpsMirrorHorz),
+                div({ class: "selectionOps-action-controls"}, this._selectionOpsMirrorVert))),
+        div({ class: "selectionOps-action"},
+            div({ class: "tip", onclick: () => this._openPrompt("selectionFlatten") }, "Flatten"),
+            div({ class: "selectionOps-action-controls"},
+                this._selectionOpsFlatten,
+                label({ class: "checkbox-container" }, this._selectionOpsFlattenAcross, "Across")))
+    );
+    private readonly _selectionOpsRow3 = div({ class: "selectionOps-row"},
+        div({ class: "selectionOps-action"},
+            this._selectionOpsSplitLabel,
+            div({ class: "selectionOps-action-controls"},
+                div({ class: "selectionOps-row-inside"},
+                    this._selectionOpsSplit,
+                    this._selectionOpsSplitSlider.container),
+                div({ class: "selectionOps-row-inside"},
+                    label({ class: "checkbox-container" }, this._selectionOpsSplitAcross, "Across"),
+                    label({ class: "checkbox-container" }, this._selectionOpsSplitAbsolute, "Absolute"))))
+    );
+    private readonly _instrumentAndModulatorSettings: HTMLDivElement = div({ class: "instrument-settings" },
         this._instrumentSettingsGroup,
         this._modulatorGroup);
+    private readonly _selectionOps: HTMLDivElement = div({},
+        this._selectionOpsDescription,
+        this._selectionModeLabel,
+        this._selectionModeButtonsGroup,
+        this._selectionOpsRow1,
+        this._selectionOpsRow2,
+        this._selectionOpsRow3);
     private readonly _tabSettingsArea: HTMLDivElement = div({ class: 'tab-controls-area' },
         this._tabSettingsButtonsGroup,
-        this.instrumentAndModulatorSettings
+        this._instrumentAndModulatorSettings,
+        this._selectionOps
     );
+
     public readonly _settingsArea: HTMLDivElement = div({ class: "settings-area noSelection" },
         div({ class: "version-area" },
             div({ style: `text-align: center; margin: 3px 0; color: ${ColorConfig.secondaryText};` },
@@ -1601,6 +1670,15 @@ export class SongEditor {
         this._algorithmSelect.addEventListener("change", this._whenSetAlgorithm);
         this._tabButtonInstrument.addEventListener("change", () => this._whenSelectTab(TabSettingType.EditInstrument));
         this._tabButtonSelection.addEventListener("change", () => this._whenSelectTab(TabSettingType.EditSelection));
+        this._selectionModeBtnMove.addEventListener("change", () => this._whenSelectionModeChanged(SelectionMode.Move));
+        this._selectionModeBtnStretch.addEventListener("change", () => this._whenSelectionModeChanged(SelectionMode.Stretch));
+        [this._selectionOpsMerge, this._selectionOpsBridge, this._selectionOpsSpread, this._selectionOpsMirrorHorz, this._selectionOpsMirrorVert, this._selectionOpsFlatten, this._selectionOpsSplit]
+            .forEach((o) => { o.addEventListener("click", this._whenSettingButtonClicked); o.addEventListener("mouseenter", this._whenSettingButtonEnter); });
+        this._selectionOpsSplitSlider.input.addEventListener("input", this._updateSplitSliderLabel);
+        this._selectionOpsSplitSlider.input.addEventListener("change", this._updateSplitSliderLabel);
+        this._selectionOpsSplitAcross.addEventListener("change", this._updateSplitSliderLabel);
+        this._selectionOpsSplitAbsolute.addEventListener("change", this._updateSplitSliderLabel);
+        this._updateSplitSliderLabel(); // Initial label set
         this._instrumentsButtonBar.addEventListener("click", this._whenSelectInstrument);
         //this._customizeInstrumentButton.addEventListener("click", this._whenCustomizePressed);
         this._feedbackTypeSelect.addEventListener("change", this._whenSetFeedbackType);
@@ -2217,8 +2295,9 @@ export class SongEditor {
         this._sampleLoadingStatusContainer.style.display = this._doc.prefs.showSampleLoadingStatus ? "" : "none";
         this._instrumentCopyGroup.style.display = this._doc.prefs.instrumentCopyPaste ? "" : "none";
         this._instrumentExportGroup.style.display = this._doc.prefs.instrumentImportExport ? "" : "none";
-        this.instrumentAndModulatorSettings.style.display = this._doc.viewedTab == TabControls[TabSettingType.EditInstrument] ? "" : "none";
-        this.instrumentAndModulatorSettings.style.scrollbarWidth = this._doc.prefs.showInstrumentScrollbars ? "" : "none";
+        this._instrumentAndModulatorSettings.style.display = this._doc.viewedTab == TabControls[TabSettingType.EditInstrument] ? "" : "none";
+        this._selectionOps.style.display = this._doc.viewedTab === TabControls[TabSettingType.EditSelection] ? "" : "none";
+        this._instrumentAndModulatorSettings.style.scrollbarWidth = this._doc.prefs.showInstrumentScrollbars ? "" : "none";
         if (document.getElementById('text-content'))
             document.getElementById('text-content')!.style.display = this._doc.prefs.showDescription ? "" : "none";
 
@@ -3479,14 +3558,14 @@ export class SongEditor {
         // auto-scroll the settings areas to ensure the new settings are visible.
         if (this._doc.addedEffect) {
             const envButtonRect: DOMRect = this._addEnvelopeButton.getBoundingClientRect();
-            const instSettingsRect: DOMRect = this.instrumentAndModulatorSettings.getBoundingClientRect();
+            const instSettingsRect: DOMRect = this._instrumentAndModulatorSettings.getBoundingClientRect();
             const settingsRect: DOMRect = this._settingsArea.getBoundingClientRect();
-            this.instrumentAndModulatorSettings.scrollTop += Math.max(0, envButtonRect.top - (instSettingsRect.top + instSettingsRect.height));
+            this._instrumentAndModulatorSettings.scrollTop += Math.max(0, envButtonRect.top - (instSettingsRect.top + instSettingsRect.height));
             this._settingsArea.scrollTop += Math.max(0, envButtonRect.top - (settingsRect.top + settingsRect.height));
             this._doc.addedEffect = false;
         }
         if (this._doc.addedEnvelope) {
-            this.instrumentAndModulatorSettings.scrollTop = this.instrumentAndModulatorSettings.scrollHeight;
+            this._instrumentAndModulatorSettings.scrollTop = this._instrumentAndModulatorSettings.scrollHeight;
             this._settingsArea.scrollTop = this._settingsArea.scrollHeight;
             this._doc.addedEnvelope = false;
         }
@@ -4836,6 +4915,64 @@ export class SongEditor {
 
         this._doc.record(new ChangeViewedTab(this._doc, type))
     }
+
+    private _whenSelectionModeChanged = (type: SelectionMode): void => {
+        [
+            {type: SelectionMode.Move, obj: this._selectionModeMoveLabel},
+            {type: SelectionMode.Stretch, obj: this._selectionModeStretchLabel}
+        ].forEach((entry) => {
+            if (type == entry.type) {
+                if (!entry.obj.classList.contains('selected-tab')) { entry.obj.classList.add('selected-tab') }
+            } else {
+                entry.obj.classList.remove('selected-tab')
+            }
+        })
+
+        this._patternEditor.switchEditingMode(type);
+        this._selectionModeLabel.innerText = (type === SelectionMode.Move) ? "Move mode" : "Stretch mode";
+    }
+
+    private _whenSettingButtonClicked = (event: MouseEvent): void => {
+        if (event.target === this._selectionOpsMerge) {
+            this._doc.selection.noteMerge(!this._selectionOpsMergeAll.checked);
+        } else if (event.target === this._selectionOpsBridge) {
+            this._doc.selection.noteBridge(this._selectionOpsBridgeBend.checked, false);
+        } else if (event.target === this._selectionOpsSpread) {
+            this._doc.selection.noteSpreadAcross();
+        } else if (event.target === this._selectionOpsFlatten) {
+            this._doc.selection.noteFlattenAcross(!this._selectionOpsFlattenAcross.checked);
+        } else if (event.target === this._selectionOpsMirrorHorz) {
+            this._doc.selection.noteMirrorAcross(false);
+        } else if (event.target === this._selectionOpsMirrorVert) {
+            this._doc.selection.noteMirrorAcross(true);
+        } else if (event.target === this._selectionOpsSplit) {
+            this._doc.selection.noteSplitAcross(Number(this._selectionOpsSplitSlider.input.value),
+            this._selectionOpsSplitAbsolute.checked, !this._selectionOpsSplitAcross.checked)
+        }
+
+        // Remove focus highlight on click (restored on mouse re-enter).
+        if (event.target instanceof HTMLButtonElement && !event.target.classList.contains("focus-hidden")) {
+            event.target.classList.add("focus-hidden");
+        }
+    }
+
+    private _whenSettingButtonEnter = (event: MouseEvent): void => {
+        if (event.target instanceof HTMLButtonElement && event.target.classList.contains("focus-hidden")) {
+            event.target.classList.remove("focus-hidden");
+        }
+    }
+
+    private _updateSplitSliderLabel = (): void => {
+        const num = this._selectionOpsSplitSlider.input.valueAsNumber;
+        this._selectionOpsSplitLabel.innerText =
+            this._selectionOpsSplitAcross.checked && !this._selectionOpsSplitAbsolute.checked
+                ? `Make ${num} cuts`:
+            !this._selectionOpsSplitAcross.checked && !this._selectionOpsSplitAbsolute.checked
+                ? `Cut each note ${num} times`:
+            !this._selectionOpsSplitAcross.checked && this._selectionOpsSplitAbsolute.checked
+                ? `Cut every ${num} parts for each note`:
+            `Cut every ${num} parts`;
+    }
     
     private _whenSelectInstrument = (event: MouseEvent): void => {
         if (event.target == this._instrumentAddButton) {
@@ -5114,32 +5251,11 @@ export class SongEditor {
             case "transposeDown":
                 this._doc.selection.transpose(false, false);
                 break;
-            case "noteOpMerge":
-                this._doc.selection.noteMerge(true);
-                break;
-            case "noteOpBridge":
-                this._doc.selection.noteBridge(true, true);
-                break;
-            case "noteOpSegmentize":
-                this._doc.selection.noteSegmentizeAcross(2, false, true);
-                break;
-            case "flattenNotes":
-                this._doc.selection.noteFlattenAcross();
-                break;
             case "stretchNotes":
                 this._doc.selection.noteStretchHorizontal(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
                 break;
             case "stretchNotesVertical":
                 this._doc.selection.noteStretchVertical(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
-                break;
-            case "noteOpMirrorHorizontal":
-                this._doc.selection.noteMirrorAcross(false);
-                break;
-            case "noteOpMirrorVertical":
-                this._doc.selection.noteMirrorAcross(true);
-                break;
-            case "spreadAcross":
-                this._doc.selection.noteSpreadAcross();
                 break;
             case "stutterNotes":
                 this._doc.selection.noteStutterAcross();

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -792,9 +792,6 @@ export class SongEditor {
         option({ value: "duplicatePatterns" }, "Duplicate Reused Patterns (D)"),
         option({ value: "transposeUp" }, "Move Notes Up (+ or ⇧+)"),
         option({ value: "transposeDown" }, "Move Notes Down (- or ⇧-)"),
-        option({ value: "stretchNotes" }, "Stretch Notes Horz"),
-        option({ value: "stretchNotesVertical" }, "Stretch Notes Vert"),
-        option({ value: "stutterNotes"}, "Stutter Notes"),
         option({ value: "moveNotesSideways" }, "Move All Notes Sideways... (W)"),
 	    option({ value: "generateEuclideanRhythm" }, "Generate Euclidean Rhythm... (E)"),
         option({ value: "beatsPerBar" }, "Change Beats Per Bar... (⇧B)"),
@@ -5114,15 +5111,6 @@ export class SongEditor {
                 break;
             case "transposeDown":
                 this._doc.selection.transpose(false, false);
-                break;
-            case "stretchNotes":
-                this._doc.selection.noteStretchHorizontal(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
-                break;
-            case "stretchNotesVertical":
-                this._doc.selection.noteStretchVertical(this._doc.selection.patternSelectionStart, this._doc.selection.patternSelectionEnd);
-                break;
-            case "stutterNotes":
-                this._doc.selection.noteStutterAcross();
                 break;
             case "selectAll":
                 this._doc.selection.selectAll();

--- a/editor/SongPerformance.ts
+++ b/editor/SongPerformance.ts
@@ -126,7 +126,7 @@ export class SongPerformance {
 	}
 	
 	private _getCurrentPlayheadPart(): number {
-		const currentPart: number = this._doc.synth.playhead * this._doc.song.beatsPerBar * Config.partsPerBeat;
+		const currentPart: number = this._doc.synth.playhead * this._doc.song.partsPerPattern;
 		if (this._doc.prefs.snapRecordedNotesToRhythm) {
 			const minDivision: number = this._getMinDivision();
 			return Math.round(currentPart / minDivision) * minDivision;
@@ -167,7 +167,7 @@ export class SongPerformance {
 			return false;
 		}
 		
-		const partsPerBar: number = this._doc.song.beatsPerBar * Config.partsPerBeat;
+		const partsPerBar: number = this._doc.song.partsPerPattern;
 		const oldPart: number = this._playheadPart % partsPerBar;
 		const oldBar: number = Math.floor(this._playheadPart / partsPerBar);
 		const oldPlayheadPart: number = this._playheadPart;
@@ -269,7 +269,7 @@ export class SongPerformance {
 			return false;
 		}
 		
-		const partsPerBar: number = this._doc.song.beatsPerBar * Config.partsPerBeat;
+		const partsPerBar: number = this._doc.song.partsPerPattern;
 		const oldPart: number = this._bassPlayheadPart % partsPerBar;
 		const oldBar: number = Math.floor(this._bassPlayheadPart / partsPerBar);
 		const oldPlayheadPart: number = this._bassPlayheadPart;

--- a/editor/TabControls.ts
+++ b/editor/TabControls.ts
@@ -11,6 +11,6 @@ export type TabControl = {
 }
 
 export const TabControls: { [key: number]: TabControl } = {
-	[TabSettingType.EditInstrument]: { type: TabSettingType.EditInstrument, icon: '🎺' },
+	[TabSettingType.EditInstrument]: { type: TabSettingType.EditInstrument, icon: '🎺︎' },
 	[TabSettingType.EditSelection]: { type: TabSettingType.EditSelection, icon: '⬚' }
 }

--- a/editor/TabControls.ts
+++ b/editor/TabControls.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2012-2022 John Nesky and contributing authors, distributed under the MIT license, see accompanying the LICENSE.md file.
+
+export enum TabSettingType {
+	EditInstrument = 0,
+	EditSelection = 1
+}
+
+export type TabControl = {
+	icon: string,
+	type: TabSettingType
+}
+
+export const TabControls: { [key: number]: TabControl } = {
+	[TabSettingType.EditInstrument]: { type: TabSettingType.EditInstrument, icon: '🎺' },
+	[TabSettingType.EditSelection]: { type: TabSettingType.EditSelection, icon: '⬚' }
+}

--- a/editor/TipPrompt.ts
+++ b/editor/TipPrompt.ts
@@ -14,7 +14,7 @@ export class TipPrompt implements Prompt {
 		
 	constructor(private _doc: SongDocument, type: string) {
 		let message: HTMLDivElement;
-			
+
 		switch (type) {
 			case "scale": {
 				message = div(
@@ -26,8 +26,8 @@ export class TipPrompt implements Prompt {
 			case "selectionMerge": {
 				message = div(
 					h2("Merge"),
-					p("This combines adjacent, touching notes into one. If \"All\" is active, it works regardless of pitch and will even shift notes as needed to connect them."),
-					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+					p("This makes notes that touch turn into one continuous note. If \"All\" is active, it will merge all notes no matter what, and will even shift notes if it helps to connect them."),
+					p("Merge affects on-screen notes that fit within your selection. It also works across channel selections.")
 				);
 				break;
 			}
@@ -42,29 +42,30 @@ export class TipPrompt implements Prompt {
 			case "selectionSpread": {
 				message = div(
 					h2("Spread"),
-					p("This redistributes the notes into the selection bounds with even spacing between them all."),
-					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+					p("This spreads notes to be evenly-spaced in the selection. If only one note is selected, it centers it."),
+					p("If \"Pitch\" is active, it spreads the notes vertically like a staircase going up (crescendo) or down (decrescendo), whichever is closer."),
+					p("Spread affects on-screen notes that fit within your selection. It also works across channel selections.")
 				);
 			} break;
 			case "selectionMirror": {
 				message = div(
 					h2("Mirror"),
 					p("The mirror operations cause notes to appear at the opposite ends, proportionally, of the range. For vertical mirror, the range is detected as the distance from lowest and highest existing notes."),
-					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+					p("Mirror affects on-screen notes that fit within your selection. It also works across channel selections.")
 				);
 			} break;
 			case "selectionFlatten": {
 				message = div(
 					h2("Flatten"),
-					p("This removes all pitch bends from notes. If \"Across\" is active, it also sets the notes to the average of their pitches."),
-					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+					p("This removes all pitch bends from notes. If \"Pitch\" is active, it also sets the notes to the average of their pitches."),
+					p("Flatten affects on-screen notes that fit within your selection. It also works across channel selections.")
 				);
 			} break;
 			case "selectionSplit": {
 				message = div(
 					h2("Split"),
 					p("This makes a number of evenly-spaced cuts across the selected range, which separate notes."),
-					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+					p("Split affects on-screen notes that fit within your selection. It also works across channel selections.")
 				);
 			} break;
 			case "key": {

--- a/editor/TipPrompt.ts
+++ b/editor/TipPrompt.ts
@@ -23,6 +23,50 @@ export class TipPrompt implements Prompt {
 					p("The most common scales are major and minor. Assuming your song uses all pitches in the scale and especially \"tonic\" pitches (the purple rows in the pattern editor) then major scales tend to sound more playful or optimistic, whereas minor scales sound more serious or sad."),
 				);
 			} break;
+			case "selectionMerge": {
+				message = div(
+					h2("Merge"),
+					p("This combines adjacent, touching notes into one. If \"All\" is active, it works regardless of pitch and will even shift notes as needed to connect them."),
+					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+				);
+				break;
+			}
+			case "selectionBridge": {
+				message = div(
+					h2("Bridge"),
+					p("This creates notes in the empty space to the right of other notes. If \"Bend\" is active, the new notes will end at the starting pitch of the next note."),
+					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+				);
+				break;
+			}
+			case "selectionSpread": {
+				message = div(
+					h2("Spread"),
+					p("This redistributes the notes into the selection bounds with even spacing between them all."),
+					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+				);
+			} break;
+			case "selectionMirror": {
+				message = div(
+					h2("Mirror"),
+					p("The mirror operations cause notes to appear at the opposite ends, proportionally, of the range. For vertical mirror, the range is detected as the distance from lowest and highest existing notes."),
+					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+				);
+			} break;
+			case "selectionFlatten": {
+				message = div(
+					h2("Flatten"),
+					p("This removes all pitch bends from notes. If \"Across\" is active, it also sets the notes to the average of their pitches."),
+					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+				);
+			} break;
+			case "selectionSplit": {
+				message = div(
+					h2("Split"),
+					p("This makes a number of evenly-spaced cuts across the selected range, which separate notes."),
+					p("It affects only notes in the selected range, or all notes on the pattern(s) if none are selected.")
+				);
+			} break;
 			case "key": {
 				message = div(
 					h2("Song Key"),

--- a/editor/changes.ts
+++ b/editor/changes.ts
@@ -134,7 +134,7 @@ export function generateScaleMap(oldScaleFlags: ReadonlyArray<boolean>, newScale
     return fullPitchMap;
 }
 
-function removeRedundantPins(pins: NotePin[]): void {
+export function removeRedundantPins(pins: NotePin[]): void {
     for (let i: number = 1; i < pins.length - 1;) {
         if (pins[i - 1].interval == pins[i].interval &&
             pins[i].interval == pins[i + 1].interval &&

--- a/editor/changes.ts
+++ b/editor/changes.ts
@@ -4184,7 +4184,7 @@ export class ChangeNotesAdded extends UndoableChange {
             .filter((note) => !this._oldNotes.includes(note))
             .concat(this._newNotes);
 
-        this._pattern.notes.sort((note1, note2) => note1.start - note2.start);
+        this._pattern.notes.sort(function (a, b) { return (a.start == b.start) ? a.pitches[0] - b.pitches[0] : a.start - b.start; })
         this._doc.notifier.changed();
     }
 
@@ -4193,7 +4193,7 @@ export class ChangeNotesAdded extends UndoableChange {
             .filter((note) => !this._newNotes.includes(note))
             .concat(this._oldNotes);
 
-        this._pattern.notes.sort((note1, note2) => note1.start - note2.start);
+        this._pattern.notes.sort(function (a, b) { return (a.start == b.start) ? a.pitches[0] - b.pitches[0] : a.start - b.start; })
         this._doc.notifier.changed();
     }
 }

--- a/editor/changes.ts
+++ b/editor/changes.ts
@@ -3621,7 +3621,7 @@ export class ChangeMoveNotesSideways extends ChangeGroup {
         const boxY1 = Math.max(doc.selection.boxSelectionY0, doc.selection.boxSelectionY1);
 
         let partsToMove: number = Math.round((beatsToMove % doc.song.beatsPerBar) * Config.partsPerBeat);
-        if (partsToMove < 0) partsToMove += doc.song.beatsPerBar * Config.partsPerBeat;
+        if (partsToMove < 0) partsToMove += doc.song.partsPerPattern;
         if (partsToMove == 0.0) return;
 
         switch (strategy) {
@@ -3736,7 +3736,7 @@ export class ChangeBeatsPerBar extends ChangeGroup {
                         const sequence: ChangeSequence = new ChangeSequence();
                         for (let i: number = 0; i < doc.song.getChannelCount(); i++) {
                             for (let j: number = 0; j < doc.song.channels[i].patterns.length; j++) {
-                                sequence.append(new ChangeNoteTruncate(doc, doc.song.channels[i].patterns[j], newValue * Config.partsPerBeat, doc.song.beatsPerBar * Config.partsPerBeat, null, true));
+                                sequence.append(new ChangeNoteTruncate(doc, doc.song.channels[i].patterns[j], newValue * Config.partsPerBeat, doc.song.partsPerPattern, null, true));
                             }
                         }
                     }
@@ -4596,8 +4596,8 @@ export class ChangeDragSelectedNotes extends ChangeSequence {
 
         const oldStart: number = doc.selection.patternSelectionStart;
         const oldEnd: number = doc.selection.patternSelectionEnd;
-        const newStart: number = Math.max(0, Math.min(doc.song.beatsPerBar * Config.partsPerBeat, oldStart + parts));
-        const newEnd: number = Math.max(0, Math.min(doc.song.beatsPerBar * Config.partsPerBeat, oldEnd + parts));
+        const newStart: number = Math.max(0, Math.min(doc.song.partsPerPattern, oldStart + parts));
+        const newEnd: number = Math.max(0, Math.min(doc.song.partsPerPattern, oldEnd + parts));
         if (newStart == newEnd) {
             // Just erase the current contents of the selection:
             this.append(new ChangeNoteTruncate(doc, pattern, oldStart, oldEnd, null, true));

--- a/editor/changes.ts
+++ b/editor/changes.ts
@@ -4181,7 +4181,13 @@ export class ChangeNotesAdded extends UndoableChange {
 
     protected _doForwards(): void {
         this._pattern.notes = this._pattern.notes
-            .filter((note) => !this._oldNotes.includes(note))
+            .filter((note) => !this._oldNotes.some(old =>
+                old.continuesLastPattern === note.continuesLastPattern &&
+                old.start === note.start && old.end === note.end &&
+                old.pins.every((_, index) => old.pins[index].interval === note.pins[index].interval
+                    && old.pins[index].size === note.pins[index].size
+                    && old.pins[index].time === note.pins[index].time) &&
+                old.pitches.every((_, index) => old.pitches[index] === note.pitches[index])))
             .concat(this._newNotes);
 
         this._pattern.notes.sort(function (a, b) { return (a.start == b.start) ? a.pitches[0] - b.pitches[0] : a.start - b.start; })

--- a/editor/changes.ts
+++ b/editor/changes.ts
@@ -7,6 +7,7 @@ import { Change, ChangeGroup, ChangeSequence, UndoableChange } from "./Change";
 import { SongDocument } from "./SongDocument";
 import { ColorConfig } from "./ColorConfig";
 import { Slider } from "./HTMLWrapper";
+import { TabControls } from "./TabControls";
 
 export function patternsContainSameInstruments(pattern1Instruments: number[], pattern2Instruments: number[]): boolean {
     const pattern2Has1Instruments: boolean = pattern1Instruments.every(instrument => pattern2Instruments.indexOf(instrument) != -1);
@@ -2958,6 +2959,17 @@ export class ChangeRemoveChannelInstrument extends Change {
 
         doc.notifier.changed();
         this._didSomething();
+    }
+}
+
+export class ChangeViewedTab extends Change {
+    constructor(doc: SongDocument, index: number) {
+        super();
+        if (doc.viewedTab.type != index && TabControls[index]) {
+            doc.viewedTab = TabControls[index];
+        doc.notifier.changed();
+        this._didSomething();
+        }
     }
 }
 

--- a/editor/changesNoteOps.ts
+++ b/editor/changesNoteOps.ts
@@ -1,11 +1,9 @@
-// Copyright (c) 2025 ThinkAndWander and contributing authors, distributed under the MIT license, per the accompanying LICENSE.md file.
-
-import { Config } from "../synth/SynthConfig";
-import { NotePin, Note, Pattern } from "../synth/synth";
+import { NotePin, Note, Pattern, Config } from "../synth/synth";
 import { ChangeSequence } from "./Change";
 import { SongDocument } from "./SongDocument";
 import { ChangeNoteAdded, ChangeNotesAdded, ChangeSplitNotesAtPoint, ChangeSplitNotesAtSelection } from "./changes";
 
+/** Merge notes that touch into one. */
 export class ChangeMergeAcrossAdjacent extends ChangeSequence {
     constructor(doc: SongDocument, pattern: Pattern) {
         super();
@@ -53,13 +51,14 @@ export class ChangeMergeAcrossAdjacent extends ChangeSequence {
     }
 }
 
+/** Merge notes in selected range. */
 export class ChangeMergeAcross extends ChangeSequence {
     constructor(doc: SongDocument, pattern: Pattern, x1?: number, x2?: number) {
         super();
 
-        x1 = x1 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
-        x2 = x2 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.beatsPerBar * Config.partsPerBeat);
-        if (x1 < 0 || x2 <= x1 || x2 > doc.song.beatsPerBar * Config.partsPerBeat) { return; }
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        if (x1 < 0 || x2 <= x1 || x2 > doc.song.partsPerPattern) { return; }
         if (pattern.notes.length == 0) { return; }
 
         let firstNoteIndex = 0;
@@ -144,13 +143,17 @@ export class ChangeMergeAcross extends ChangeSequence {
     }
 }
 
+/** Bridge between notes in selected range. */
 export class ChangeBridgeAcross extends ChangeSequence {
     private _notesInserted: {insertAt: number, note: Note}[] = [];
     private _pattern: Pattern;
-    constructor(doc: SongDocument, pattern: Pattern, doBends: boolean, copyEnds: boolean) {
+    constructor(doc: SongDocument, pattern: Pattern, doBends: boolean, copyEnds: boolean, x1?: number, x2?: number) {
         super();
         this._pattern = pattern;
 
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        if (x1 < 0 || x2 <= x1 || x2 > doc.song.partsPerPattern) { return; }
         if (pattern.notes.length == 0) { return; }
 
         let note: Note;
@@ -160,14 +163,12 @@ export class ChangeBridgeAcross extends ChangeSequence {
             note = pattern.notes[i];
 
             // Skip out-of-bounds notes
-            if (doc.selection.patternSelectionActive) {
-                if (note.end <= doc.selection.patternSelectionStart) {
-                    noteLeftOfSelection = i;
-                    continue;
-                }
-                if (note.start >= doc.selection.patternSelectionEnd) {
-                    break;
-                }
+            if (note.end <= x1) {
+                noteLeftOfSelection = i;
+                continue;
+            }
+            if (note.start >= x2) {
+                break;
             }
 
             // Don't bridge from the note left of selection to first within.
@@ -222,6 +223,7 @@ export class ChangeBridgeAcross extends ChangeSequence {
     }
 }
 
+/** Draw cuts across notes in selected range. */
 export class ChangeSegmentizeAcross extends ChangeSequence {
     private _pattern: Pattern;
     private _splitNotes: Note[] = [];
@@ -230,8 +232,9 @@ export class ChangeSegmentizeAcross extends ChangeSequence {
         super();
         this._pattern = pattern;
 
-        x1 = x1 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
-        x2 = x2 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.beatsPerBar * Config.partsPerBeat);
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        if (pattern.notes.length === 0) { return; }
 
         const range = x2 - x1;
         if (numCuts < 1) { return; }
@@ -289,99 +292,234 @@ export class ChangeSegmentizeAcross extends ChangeSequence {
     }
 }
 
-export class ChangeDivideSelfAcross extends ChangeSequence {
-    constructor(doc: SongDocument, pattern: Pattern) {
+/** Stacks all notes in range to the left side so that they're all touching. */
+export class ChangeStackLeftAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern, x1?: number, x2?: number) {
         super();
+
         if (doc.selection.patternSelectionActive) {
             this.append(new ChangeSplitNotesAtPoint(doc, pattern, doc.selection.patternSelectionStart));
-            doc.notifier.changed();
-            this._didSomething();
         }
+
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        if (x1 < 0 || x2 <= x1) { return; }
+        if (pattern.notes.length === 0) { return; }
+
+        let firstNote = false;
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
+
+            if (note.start < x2 && note.end > x1) {
+                if (!firstNote) {
+                    firstNote = true;
+                    note.start = x1;
+                    note.end = note.start + note.pins[note.pins.length - 1].time;
+                } else if (i > 0) {
+                    const prevNote = pattern.notes[i - 1];
+                    note.start = prevNote.end;
+                    note.end = note.start + note.pins[note.pins.length - 1].time;
+                }
+            }
+        }
+
+        doc.notifier.changed();
+        this._didSomething();
     }
 }
 
-export class ChangeFlattenAcross extends ChangeSequence {
-    constructor(doc: SongDocument, pattern: Pattern) {
+/** Cumulatively shifts every note up or down with an optional vertical multiplier. Makes crescendos and descendos. */
+export class ChangeStepAcross extends ChangeSequence {
+    constructor(doc: SongDocument, channelIndex: number, pattern: Pattern, step?: number, x1?: number, x2?: number) {
         super();
 
         if (doc.selection.patternSelectionActive) {
-            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+            this.append(new ChangeSplitNotesAtPoint(doc, pattern, doc.selection.patternSelectionStart));
         }
 
-        for (const note of pattern.notes) {
-            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
-                continue;
+        const pitchLimit = doc.song.getChannelIsNoise(channelIndex) ? Config.drumCount - 1 : Config.maxPitch;
+
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        step ??= 1;
+
+        if (x1 < 0 || x2 <= x1) { return; }
+        if (pattern.notes.length === 0) { return; }
+
+        let firstIndex = -1;
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
+
+            if (note.start < x2 && note.end > x1) {
+                if (firstIndex === -1) { firstIndex = i; }
+                note.pitches = note.pitches.map((pitch) => Math.min(Math.max(pitch + step * (i - firstIndex), 0), pitchLimit));
             }
-
-            // TODO
         }
+
+        doc.notifier.changed();
+        this._didSomething();
     }
 }
 
-export class ChangeStackLeftAcross extends ChangeSequence {
-    constructor(doc: SongDocument, pattern: Pattern) {
-        super();
-
-        if (doc.selection.patternSelectionActive) {
-            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
-        }
-
-        for (const note of pattern.notes) {
-            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
-                continue;
-            }
-
-            // TODO
-        }
-    }
-}
-
+/** Spreads notes in range evenly across it. */
 export class ChangeSpreadAcross extends ChangeSequence {
-    constructor(doc: SongDocument, pattern: Pattern) {
+    constructor(doc: SongDocument, pattern: Pattern, x1?: number, x2?: number) {
         super();
+
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        if (x1 < 0 || x2 <= x1) { return; }
+        if (pattern.notes.length === 0) { return; }
+
+        this.append(new ChangeSplitNotesAtPoint(doc, pattern, x1));
+        this.append(new ChangeSplitNotesAtPoint(doc, pattern, x2));
+
+        // Get the total free space available and number of notes in the range.
+        let firstNote = false;
+        let totalSpace = 0;
+        let noteCount = 0;
+        let finalIndex = -1;
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
+
+            if (note.start < x2 && note.end > x1) {
+                noteCount++;
+                if (!firstNote) {
+                    firstNote = true;
+                    totalSpace += note.start - x1;
+                } else {
+                    totalSpace += note.start - pattern.notes[i - 1].end;
+                }
+
+                finalIndex = i;
+            }
+        }
+        if (finalIndex > -1) {
+            totalSpace += x2 - pattern.notes[finalIndex].end;
+        }
+
+        if (noteCount === 0 || totalSpace === 0) { return; }
+
+        // Stack left, leaving no space.
+        const spaceBetween = totalSpace / (noteCount - 1);
+        this.append(new ChangeStackLeftAcross(doc, pattern, x1, x2));
+
+        // Add space between.
+        let firstIndex = -1;
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
+
+            if (note.start < x2 && note.end > x1) {
+                if (firstIndex === -1) {
+                    firstIndex = i;
+                } else {
+                    note.start += Math.floor(spaceBetween * (i - firstIndex));
+                    note.end = note.start + note.pins[note.pins.length - 1].time;
+                }
+            }
+        }
+
+        doc.notifier.changed();
+        this._didSomething();
+    }
+}
+
+/** Randomly nudges notes in range left/right by 1 time unit if possible. */
+export class ChangeTapNotesAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern, x1?: number, x2?: number) {
+        super();
+
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        if (x1 < 0 || x2 <= x1) { return; }
+        if (pattern.notes.length === 0) { return; }
+
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
+
+            if (note.start < x2 && note.end > x1) {
+                const canTapLeft = note.start > x1
+                    && (i == 0 || note.start - pattern.notes[i - 1].end > 0);
+
+                const canTapRight = note.end < x2
+                    && note.end < doc.song.partsPerPattern
+                    && (i === pattern.notes.length - 1 || pattern.notes[i + 1].start - note.end > 0);
+
+                if (canTapLeft && Math.random() >= 0.5) { note.start--; note.end--; }
+                if (canTapRight && Math.random() >= 0.5) { note.start++; note.end++; }
+            }
+        }
+
+        doc.notifier.changed();
+        this._didSomething();
+    }
+}
+
+/** Mirrors notes in the given range horizontally. */
+export class ChangeMirrorHorizontal extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern, inPlace?: boolean, x1?: number, x2?: number) {
+        super();
+
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        const center = (x1 + x2) / 2;
+        
+        if (x1 < 0 || x2 <= x1) { return; }
+        if (pattern.notes.length === 0) { return; }
 
         if (doc.selection.patternSelectionActive) {
             this.append(new ChangeSplitNotesAtSelection(doc, pattern));
         }
 
-        for (const note of pattern.notes) {
-            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
-                continue;
-            }
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
 
-            // TODO
+            if (note.end > x1 && note.start < x2) {
+                for (let j = 0; j < note.pins.length; j++) {
+                    note.pins[j].time = Math.abs(note.pins[j].time - note.pins[note.pins.length - 1].time);
+                }
+                note.pins.reverse();
+
+                // It's so simple...but it was too hard for me to compute. So here's 2 functions.
+                if (!inPlace) {
+                    if (note.start < center) {
+                        const endDist = center - note.end;
+                        note.start = center + endDist
+                    } else {
+                        const startDist = note.start - center;
+                        note.start = center - startDist - note.pins[note.pins.length - 1].time;
+                    }
+
+                    note.end = note.start + note.pins[note.pins.length - 1].time;
+                }
+            }
         }
+        pattern.notes.sort((a, b) => a.start - b.start); // Keep it sorted.
+
+        doc.notifier.changed();
+        this._didSomething();
     }
 }
 
-export class ChangeMirrorAcross extends ChangeSequence {
-    constructor(doc: SongDocument, pattern: Pattern, mirrorVertically: boolean) {
-        super();
-
-        if (doc.selection.patternSelectionActive) {
-            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
-        }
-
-        for (const note of pattern.notes) {
-            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
-                continue;
-            }
-
-            // TODO
-        }
-    }
-}
-
-export class ChangeStretchAcross extends ChangeSequence {
+/** Stretch/shrink the selected range and transpose it to the new location. newX2 < newX1 can mirror notes. */
+export class ChangeStretchHorizontal extends ChangeSequence {
     constructor(doc: SongDocument, pattern: Pattern, oldX1: number, oldX2: number, newX1: number, newX2: number) {
         super();
 
-        newX2 = Math.min(newX2, doc.song.beatsPerBar * Config.partsPerBeat);
+        newX2 = Math.min(newX2, doc.song.partsPerPattern);
 
-        if (oldX1 < 0 || oldX2 <= oldX1 || newX1 < 0 || newX2 <= newX1) { return; }
+        if (oldX1 < 0 || oldX2 <= oldX1 || newX1 < 0 || newX2 < 0 || newX1 == newX2
+            || newX1 > doc.song.partsPerPattern || newX2 > doc.song.partsPerPattern) {
+            return;
+        }
 
         if (doc.selection.patternSelectionActive) {
             this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+        }
+
+        if (newX2 < newX1) {
+            this.append(new ChangeMirrorHorizontal(doc, pattern, true, oldX1, oldX2));
+            [newX1, newX2] = [newX2, newX1] //swap
         }
 
         const newNotes: Note[] = [];
@@ -458,4 +596,123 @@ export class ChangeStretchAcross extends ChangeSequence {
         doc.notifier.changed();
         this._didSomething();
     }
+}
+
+/** Stretch/shrink a section of notes vertically across center with a multiplier/addition for all or every note. */
+export class ChangeStretchVerticalRelative extends ChangeSequence {
+    constructor(doc: SongDocument, channelIndex: number, pattern: Pattern,
+        multBy?: number, add?: number, perNote?: boolean, x1?: number, x2?: number, yOrig?: { min: number, max: number }) {
+        super();
+
+        const pitchLimit = doc.song.getChannelIsNoise(channelIndex) ? Config.drumCount - 1 : Config.maxPitch;
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        if (x1 < 0 || x2 <= x1) { return; }
+        if (pattern.notes.length === 0) { return; }
+
+        multBy ??= 1;
+        add ??= 0;        
+
+        const stretch = (notes: Note[], bounds?: { min: number, max: number }) => {
+            const newBounds = {...(bounds ?? yOrig ?? getVerticalBounds(notes, x1, x2))};
+            const halfDist = (newBounds.max - newBounds.min) / 2;
+            const center = newBounds.min + halfDist;
+            this.append(new ChangeStretchVertical(doc, channelIndex, pattern,
+                Math.max(center - (halfDist * multBy) - add/2, 0),
+                Math.min(center + (halfDist * multBy) + add/2, pitchLimit),
+                newBounds, x1, x2));
+        }
+
+        if (perNote) {
+            pattern.notes.forEach(note => stretch([note], yOrig ?? getVerticalBounds(pattern.notes, x1, x2)));
+        } else {
+            stretch(pattern.notes);
+        }
+
+        doc.notifier.changed();
+        this._didSomething();
+    }
+}
+
+/**
+ * Stretch/shrink a section of notes vertically to fit a new vertical range. yMax < yMin can mirror notes.
+ * @param yMin Bottom of the new vertical range in absolute units
+ * @param yMax Top of the new vertical range in absolute units
+ * @param x1 Start of selection range, which defaults to active selection if any, or left side
+ * @param x2 End of selection range, which defaults to active selection if any, or right side
+ * @param yOrig Instead of detecting the original note bounds, uses this range when provided (range not safety-checked). This
+ * is useful when the function is iteratively applied per-note and those notes need the context of their combined range
+ */
+export class ChangeStretchVertical extends ChangeSequence {
+    constructor(doc: SongDocument, channelIndex: number, pattern: Pattern,
+        yMin: number, yMax: number, yOrig?: { min: number, max: number }, x1?: number, x2?: number) {
+        super();
+
+        const pitchLimit = doc.song.getChannelIsNoise(channelIndex) ? Config.drumCount - 1 : Config.maxPitch;
+        x1 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 ??= (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.partsPerPattern);
+        
+        if (x1 < 0 || x2 <= x1 || yMin < 0 || yMin > pitchLimit || yMax < 0 || yMax > pitchLimit) { return; }
+        if (pattern.notes.length === 0) { return; }
+
+        if (doc.selection.patternSelectionActive) {
+            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+        }
+
+        const bounds = yOrig ?? getVerticalBounds(pattern.notes, x1, x2);
+        let origRange = bounds.max - bounds.min;
+        let newRange = yMax - yMin;
+        if (origRange === 0) { origRange = 1; newRange = 1; } // only transpose if same-line.
+
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
+
+            if (note.end > x1 && note.start < x2) {
+                // Pins are relative to pitches, so they'll fit when multiplied by the ratio of the ranges.
+                for (let j = 0; j < note.pins.length; j++) {
+                    note.pins[j].interval = Math.round(note.pins[j].interval * (newRange / origRange));
+                }
+
+                // Pitches are set to a lerped position of new range based on their position in the old range.
+                for (let j = 0; j < note.pitches.length; j++) {
+                    const origDistance = (note.pitches[j] - bounds.min) / origRange;
+                    note.pitches[j] = Math.round(yMin + origDistance * newRange);
+                }
+                note.pitches = [...new Set(note.pitches)].sort() // Keep it unique and sorted.
+            }
+        }
+
+        doc.notifier.changed();
+        this._didSomething();
+    }
+}
+
+/** Returns the pitches of the lowest and highest point among all notes in the given range. */
+function getVerticalBounds(notes: Note[], x1: number, x2: number) {
+    let absoluteMax = 0;
+    let absoluteMin = Number.MAX_SAFE_INTEGER;
+
+    for (let i = 0; i < notes.length; i++) {
+        const note = notes[i];
+
+        // For all notes in selection range
+        if (note.end > x1 && note.start < x2) {
+            let pinMax = 0;
+            let pinMin = Number.MAX_SAFE_INTEGER;
+    
+            // Find vertical min/max among pins.
+            for (let j = 0; j < note.pins.length; j++) {
+                pinMax = Math.max(pinMax, note.pins[j].interval);
+                pinMin = Math.min(pinMin, note.pins[j].interval);
+            }
+    
+            // The vertical min/max among pitches + pin min/max gives the highest/lowest points in a note.
+            for (let j = 0; j < note.pitches.length; j++) {
+                absoluteMax = Math.max(absoluteMax, note.pitches[j] + pinMax);
+                absoluteMin = Math.min(absoluteMin, note.pitches[j] + pinMin);
+            }
+        }
+    }
+
+    return { min: absoluteMin, max: absoluteMax };
 }

--- a/editor/changesNoteOps.ts
+++ b/editor/changesNoteOps.ts
@@ -1,0 +1,461 @@
+// Copyright (c) 2025 ThinkAndWander and contributing authors, distributed under the MIT license, per the accompanying LICENSE.md file.
+
+import { Config } from "../synth/SynthConfig";
+import { NotePin, Note, Pattern } from "../synth/synth";
+import { ChangeSequence } from "./Change";
+import { SongDocument } from "./SongDocument";
+import { ChangeNoteAdded, ChangeNotesAdded, ChangeSplitNotesAtPoint, ChangeSplitNotesAtSelection } from "./changes";
+
+export class ChangeMergeAcrossAdjacent extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern) {
+        super();
+
+        if (pattern.notes.length === 0) {
+            return;
+        }
+
+        let found: boolean;
+
+        do {
+            found = false;
+            for (let i = 0; i < pattern.notes.length; i++) {
+                const note = pattern.notes[i];
+
+                // Note must be within selection bounds.
+                if (doc.selection.patternSelectionActive &&
+                    (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
+                    continue;
+                }
+
+                if (i > 0) {
+                    const lastNote = pattern.notes[i - 1];
+
+                    // Last note can't be compared if it's outside selection.
+                    if (doc.selection.patternSelectionActive &&
+                        (lastNote.end <= doc.selection.patternSelectionStart || lastNote.start >= doc.selection.patternSelectionEnd)) {
+                        continue;
+                    }
+
+                    // If this and last note are touching and have the same pitches, merges them.
+                    if (note.pitches[0] + note.pins[0].interval === lastNote.pitches[0] + lastNote.pins[lastNote.pins.length - 1].interval
+                        && note.start === lastNote.end
+                        && note.pitches.length === lastNote.pitches.length && note.pitches.every((pitch) => lastNote.pitches.includes(pitch))) {
+                        this.append(new ChangeMergeAcross(doc, pattern, lastNote.start, note.end));
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        } while (found);
+
+        doc.notifier.changed();
+        this._didSomething();
+    }
+}
+
+export class ChangeMergeAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern, x1?: number, x2?: number) {
+        super();
+
+        x1 = x1 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 = x2 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.beatsPerBar * Config.partsPerBeat);
+        if (x1 < 0 || x2 <= x1 || x2 > doc.song.beatsPerBar * Config.partsPerBeat) { return; }
+        if (pattern.notes.length == 0) { return; }
+
+        let firstNoteIndex = 0;
+        let firstNote: Note | null = null;
+        let lastNote: Note | null = null;
+        const notesMergedOver: Note[] = [];
+        let notePinList: NotePin[] = [];
+
+        for (let i = 0; i < pattern.notes.length; i++) {
+            const note = pattern.notes[i];
+            if (note.end <= x1) {
+                continue;
+            }
+            if (note.start >= x2) {
+                break;
+            }
+
+            if (!firstNote) {
+                firstNote = note;
+                firstNoteIndex = i;
+                notesMergedOver.push(note);
+                notePinList = firstNote.pins;
+            }
+
+            if (note.end <= x2 && (!lastNote || note.end > lastNote.end)) {
+                lastNote = note;
+            }
+            
+            if (note != firstNote) {
+                // Accumulate pins across notes (adjust relative values based on first note)
+                for (const pin of note.pins) {
+                    const newPin = {
+                        interval: note.pitches[0] + pin.interval - firstNote.pitches[0],
+                        size: pin.size,
+                        time: note.start - firstNote.start + pin.time
+                    };
+
+                    // If the last note's ending pin is fully redundant with the start of the new note, or if it has
+                    // a length of 1, delete the last note's ending pin. Else, if they have the same time but aren't
+                    // identical, nudge the last note's end pin backwards 1 unit of time.
+                    if (notePinList.length > 0) {
+                        const lastPin = notePinList[notePinList.length - 1];
+                        const pinBeforeLast = notePinList.length > 1 ? notePinList[notePinList.length - 2] : null;
+                        if (newPin.time == lastPin.time) {
+                            // Delete prior pin if it's fully redundant with this one.
+                            // Delete prior pin if it can't be nudged back by 1 (time - 1 conflicts with pin before it).
+                            if ((newPin.interval === lastPin.interval && newPin.size === lastPin.size) ||
+                                (pinBeforeLast && lastPin.time - 1 == pinBeforeLast.time)) {
+                                notePinList.splice(notePinList.length - 1, 1);
+                            } else {
+                                // Adjust last pin time backwards by 1 since it's not redundant and is nudgeable.
+                                lastPin.time -= 1;
+                            }
+                        }
+                    }
+
+                    notePinList.push(newPin);
+                }
+
+                // We need to remove these later.
+                notesMergedOver.push(note);
+            }
+        }
+
+        // Nothing to merge if entire range is one note, or if no notes were found in range.
+        if (firstNote === lastNote || !firstNote || !lastNote) {
+            return;
+        }
+
+        // Delete all notes within range
+        for (const note of notesMergedOver) {
+            this.append(new ChangeNoteAdded(doc, pattern, note, firstNoteIndex, true));
+        }
+
+        // Span first note to the end note length and recreate all other notes as pins.
+        let firstNoteCopy = firstNote.clone();
+        firstNoteCopy.end = lastNote.end;
+        firstNoteCopy.pins = notePinList;
+        this.append(new ChangeNoteAdded(doc, pattern, firstNoteCopy, firstNoteIndex, false));
+        doc.notifier.changed();
+        this._didSomething();
+    }
+}
+
+export class ChangeBridgeAcross extends ChangeSequence {
+    private _notesInserted: {insertAt: number, note: Note}[] = [];
+    private _pattern: Pattern;
+    constructor(doc: SongDocument, pattern: Pattern, doBends: boolean, copyEnds: boolean) {
+        super();
+        this._pattern = pattern;
+
+        if (pattern.notes.length == 0) { return; }
+
+        let note: Note;
+        let prevNote: Note | null;
+        let noteLeftOfSelection: number | null = null;
+        for (let i = 0; i < pattern.notes.length; i++) {
+            note = pattern.notes[i];
+
+            // Skip out-of-bounds notes
+            if (doc.selection.patternSelectionActive) {
+                if (note.end <= doc.selection.patternSelectionStart) {
+                    noteLeftOfSelection = i;
+                    continue;
+                }
+                if (note.start >= doc.selection.patternSelectionEnd) {
+                    break;
+                }
+            }
+
+            // Don't bridge from the note left of selection to first within.
+            if (doc.selection.patternSelectionActive && i - 1 == noteLeftOfSelection) { continue; }
+
+            if (i > 0) {
+                prevNote = pattern.notes[i - 1];
+                if (note.start - prevNote.end > 0) {
+                    const startSize = copyEnds ? prevNote.pins[0].size : prevNote.pins[prevNote.pins.length - 1].size;
+                    const newNote = new Note(-1, prevNote.end, note.start, startSize, false);
+
+                    // Adjust pitch so first pin has 0 interval
+                    newNote.pitches = [];
+                    for (let pitch of prevNote.pitches) {
+                        newNote.pitches.push(pitch + prevNote.pins[prevNote.pins.length - 1].interval);
+                    }
+
+                    if (doBends) {
+                        newNote.pins[1].interval = note.pitches[0] - newNote.pitches[0] + note.pins[0].interval;
+                        newNote.pins[1].size = note.pins[0].size;
+                    } else if (copyEnds) {
+                        newNote.pins[1].size = prevNote!.pins[prevNote.pins.length - 1].size;
+                    }
+
+                    this._notesInserted.push({ insertAt: i, note: newNote });
+                }
+            }
+        }
+
+        if (this._notesInserted.length === 0) {
+            return;
+        }
+        for (let i = 0; i < this._notesInserted.length; i++) {
+            this.append(new ChangeNoteAdded(doc, pattern, this._notesInserted[i].note, this._notesInserted[i].insertAt + i, false));
+        }
+
+        doc.notifier.changed();
+        this._didSomething();
+    }
+
+    /**
+     * Performs a callback per-note added from this operation. Only includes matching notes.
+     * Return true anytime to exit early.
+    */
+    public perNote(callback: (note: Note) => boolean | void) {
+        if (callback === null) { return; }
+
+        for (const entry of this._notesInserted) {
+            const match = this._pattern.notes.findIndex((note) => note === entry.note);
+			if (match !== -1 && callback(entry.note)) { return; }
+        }
+    }
+}
+
+export class ChangeSegmentizeAcross extends ChangeSequence {
+    private _pattern: Pattern;
+    private _splitNotes: Note[] = [];
+    private _cuts: number[] = [];
+    constructor(doc: SongDocument, pattern: Pattern, numCuts: number, x1?: number, x2?: number) {
+        super();
+        this._pattern = pattern;
+
+        x1 = x1 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionStart : 0);
+        x2 = x2 ?? (doc.selection.patternSelectionActive ? doc.selection.patternSelectionEnd : doc.song.beatsPerBar * Config.partsPerBeat);
+
+        const range = x2 - x1;
+        if (numCuts < 1) { return; }
+        if (numCuts > 1 && range <= 1) { return; }
+
+        let cutIndices: number[] = [];
+
+        if (numCuts === 1) { cutIndices.push(x1); }
+        else {
+            const chunk = Math.max(range / (numCuts + 1), 1); // Never less than 1 for time.
+            for (let i = 1; i < numCuts + 1; i++) {
+                // Always cut integer sizes or greater; never the same spot twice.
+                const cut = Math.round(x1 + chunk * i)
+                if (cutIndices.length === 0 || cutIndices[cutIndices.length - 1] !== cut) {
+                    cutIndices.push(cut)
+                }
+            }
+        }
+
+        for (let i = 0; i < cutIndices.length; i++) {
+            const splitOp = new ChangeSplitNotesAtPoint(doc, pattern, cutIndices[i]);
+            this.append(splitOp);
+            this._splitNotes.push(splitOp.leftNote, splitOp.rightNote);
+        }
+
+        // Split occurs across any note(s) so there may be duplicates and it's easiest to just iterate to remove them.
+        this._cuts = cutIndices;
+        this._splitNotes = this._splitNotes.filter(function(item, pos, self) {
+            return self.indexOf(item) == pos;
+        })
+
+        if (cutIndices.length > 0) {
+            doc.notifier.changed();
+            this._didSomething();    
+        }
+    }
+
+    /** Performs a callback for each cut position, providing its position. */
+    public perCut(callback: (cutPosition: number) => boolean | void) {
+        if (callback === null) { return; }
+        this._cuts.every(cut => { callback(cut) !== true })
+    }
+
+    /**
+     * Performs a callback per-note for all segments created. Only includes matching notes.
+     * Return true anytime to exit early.
+     */
+    public perNote(callback: (note: Note) => boolean | void) {
+        if (callback === null) { return; }
+
+        for (const note of this._splitNotes) {
+            const match = this._pattern.notes.findIndex((note2) => note2 === note);
+			if (match !== -1 && callback(note)) { return; }
+        }
+    }
+}
+
+export class ChangeDivideSelfAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern) {
+        super();
+        if (doc.selection.patternSelectionActive) {
+            this.append(new ChangeSplitNotesAtPoint(doc, pattern, doc.selection.patternSelectionStart));
+            doc.notifier.changed();
+            this._didSomething();
+        }
+    }
+}
+
+export class ChangeFlattenAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern) {
+        super();
+
+        if (doc.selection.patternSelectionActive) {
+            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+        }
+
+        for (const note of pattern.notes) {
+            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
+                continue;
+            }
+
+            // TODO
+        }
+    }
+}
+
+export class ChangeStackLeftAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern) {
+        super();
+
+        if (doc.selection.patternSelectionActive) {
+            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+        }
+
+        for (const note of pattern.notes) {
+            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
+                continue;
+            }
+
+            // TODO
+        }
+    }
+}
+
+export class ChangeSpreadAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern) {
+        super();
+
+        if (doc.selection.patternSelectionActive) {
+            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+        }
+
+        for (const note of pattern.notes) {
+            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
+                continue;
+            }
+
+            // TODO
+        }
+    }
+}
+
+export class ChangeMirrorAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern, mirrorVertically: boolean) {
+        super();
+
+        if (doc.selection.patternSelectionActive) {
+            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+        }
+
+        for (const note of pattern.notes) {
+            if (doc.selection.patternSelectionActive && (note.end <= doc.selection.patternSelectionStart || note.start >= doc.selection.patternSelectionEnd)) {
+                continue;
+            }
+
+            // TODO
+        }
+    }
+}
+
+export class ChangeStretchAcross extends ChangeSequence {
+    constructor(doc: SongDocument, pattern: Pattern, oldX1: number, oldX2: number, newX1: number, newX2: number) {
+        super();
+
+        newX2 = Math.min(newX2, doc.song.beatsPerBar * Config.partsPerBeat);
+
+        if (oldX1 < 0 || oldX2 <= oldX1 || newX1 < 0 || newX2 <= newX1) { return; }
+
+        if (doc.selection.patternSelectionActive) {
+            this.append(new ChangeSplitNotesAtSelection(doc, pattern));
+        }
+
+        const newNotes: Note[] = [];
+        const scaleFactor = (newX2 - newX1) / (oldX2 - oldX1);
+
+        // Construct stretched notes
+        let note: Note;
+        let prevNote: Note | null = null;
+        let oldRangeStart = -1, oldRangeEnd = -1;
+        let newRangeStart = -1, newRangeEnd = -1;
+        let minCompressedSize = 0;
+        for (let i = 0; i < pattern.notes.length; i++) {
+            note = pattern.notes[i];
+
+            // Track which notes are in the deletion ranges. All notes to be stretched will be in the old range.
+            if (note.end > newX1 && note.start < newX2) {
+                if (newRangeStart === -1) { newRangeStart = i; }
+            }
+            if (note.end > oldX1 && note.start < oldX2) {
+                if (oldRangeStart === -1) { oldRangeStart = i; }
+
+                // The new range must be at least this big to avoid loss.
+                minCompressedSize += note.pins.length;
+
+                // transpose the note, then stretch it to hold at minimum its pins.
+                const newNote = note.clone();
+                newNote.start = Math.round((newNote.start + newX1 - oldX1) * scaleFactor);
+                newNote.end += newX1 - oldX1;
+
+                let prevPin: NotePin | null = null;
+                for (const pin of newNote.pins) {
+                    // Stretch the pins, but don't allow them to overlap. Assumes they're sorted by time.
+                    pin.time = Math.round(pin.time * scaleFactor);
+                    if (prevPin && pin.time === prevPin.time) {
+                        pin.time += 1;
+                    }
+
+                    prevPin = pin;
+                }
+                newNote.end = Math.round(Math.max(
+                    newNote.start + newNote.pins[newNote.pins.length - 1].time,
+                    newNote.start + newNote.pins.length - 1));
+
+                // Move notes so they don't overlap.
+                if (prevNote && newNote.start < prevNote.end) {
+                    newNote.end += prevNote.end - newNote.start;
+                    newNote.start = prevNote.end;
+                }
+
+                newNotes.push(newNote);
+                prevNote = newNote;
+            }
+            
+            if (note.start >= oldX2 && oldRangeEnd === -1) { oldRangeEnd = i; }
+            if (note.start >= newX2 && newRangeEnd === -1) { newRangeEnd = i; }
+        }
+
+        // Do nothing if overly shrunk or out of bounds.
+        if (newX2 - newX1 < minCompressedSize ||
+            newNotes.length === 0 ||
+            newNotes[newNotes.length - 1].end > newX2) {
+            return;
+        }
+
+        // When there are no notes to the right of the range(s).
+        if (oldRangeEnd === -1) { oldRangeEnd = pattern.notes.length; }
+        if (newRangeEnd === -1) { newRangeEnd = pattern.notes.length; }
+
+        // Delete the notes in the old range, then replace the notes in the new range.
+        const oldRangeToDelete = pattern.notes.slice(oldRangeStart, oldRangeEnd)
+        const newRangeToDelete = pattern.notes.slice(newRangeStart, newRangeEnd)
+        this.append(new ChangeNotesAdded(doc, pattern, oldRangeToDelete, []));
+        this.append(new ChangeNotesAdded(doc, pattern, newRangeToDelete, newNotes));
+        doc.notifier.changed();
+        this._didSomething();
+    }
+}

--- a/editor/main.ts
+++ b/editor/main.ts
@@ -25,7 +25,7 @@ editor.mainLayer.className += " load";
 editor.mainLayer.getElementsByClassName("pattern-area")[0].className += " load";
 editor.mainLayer.getElementsByClassName("settings-area")[0].className += " load";
 editor.mainLayer.getElementsByClassName("editor-song-settings")[0].className += " load";
-editor.mainLayer.getElementsByClassName("instrument-settings-area")[0].className += " load";
+editor.mainLayer.getElementsByClassName("tab-controls-area")[0].className += " load";
 editor.mainLayer.getElementsByClassName("trackAndMuteContainer")[0].className += " load";
 editor.mainLayer.getElementsByClassName("barScrollBar")[0].className += " load";
 

--- a/editor/style.ts
+++ b/editor/style.ts
@@ -309,33 +309,36 @@ input.tab-settings-radio + div {
 	font-size: 1.5rem;
 }
 
-.beepboxEditor div.selectionOps-row {
-    display: flex;
-	margin-top: 10px;
-}
-
 .beepboxEditor div.selectionOps-row-inside {
     display: flex;
 }
 
-.beepboxEditor div.selectionOps-action-controls {
-	padding: 0.3rem;
+.beepboxEditor div.selectionOps-action {
+	display: flex;
+	align-items: center;
+	margin-bottom: 0.2rem;
 }
 
-.beepboxEditor .selectionOps-action {
-    text-align: center;
-}
-
-.beepboxEditor .selectionOps-action-controls .checkbox-container {
-    text-align: left;
-	margin-top: 0.3rem;
-}
-
-.beepboxEditor div.selectionOps-action button.selectionOps-actionbutton {
-    height: calc(1.5 * var(--button-size));
-	width: calc(1.5 * var(--button-size));
+.beepboxEditor button.selectionOps-actionbutton,
+.beepboxEditor button.selectionOps-actionbutton:focus {
+	font-size: 1rem;
+	width: var(--button-size) !important;
 	background-repeat: no-repeat;
 	background-position: center;
+}
+
+.beepboxEditor button.selectionOps-actionbutton:focus {
+    background-color: ${ColorConfig.uiWidgetFocus}
+}
+
+.beepboxEditor button.selectionOps-actionbutton + .tip,
+.beepboxEditor button.selectionOps-actionbutton + .selectionOps-actionbutton,
+.beepboxEditor .checkbox-container + .checkbox-container {
+	margin-left: 0.2rem;
+}
+
+.beepboxEditor .selectionOps-row-inside + .selectionOps-row-inside {
+	margin-top: 0.2rem;
 }
 
 .beepboxEditor .noteOpMerge { background-image: var(--internal-note-merge-symbol) !important; }

--- a/editor/style.ts
+++ b/editor/style.ts
@@ -216,7 +216,7 @@ html {
     transition-delay: 0.35s;
 }
 
-.instrument-settings-area {
+.tab-controls-area {
     opacity: 0;
     -webkit-transition: opacity 0.5s ease-in;
     -moz-transition: opacity 0.5s ease-in;
@@ -224,6 +224,49 @@ html {
     -ms-transition: opacity 0.5s ease-in;
     transition: opacity 0.5s ease-in;
     transition-delay: 0.45s;
+}
+
+.tab-settings-buttons-group {
+	 display: flex;
+}
+
+input.tab-settings-radio {
+    margin: 0;
+	padding: 0;
+	position: absolute;
+	opacity: 0;
+}
+
+div.tab-settings-radio {
+	text-align: center;
+}
+
+div.tab-settings-radiodiv {
+    margin-top: 0.5rem;
+	color: ${ColorConfig.primaryText};
+}
+
+div.tab-settings-radiodiv,
+input.tab-settings-radio {
+	height: 2rem;
+	width: 2rem;
+	padding: 0.2rem;
+	cursor: pointer;
+	border-style: solid;
+	border-width: 1px;
+	border-color: transparent;
+}
+
+div.selected-tab {
+    background-color: ${ColorConfig.boxSelectionFill};
+}
+
+div.tab-settings-radiodiv:hover {
+	border-color: ${ColorConfig.primaryText};
+}
+
+input.tab-settings-radio + div {
+	font-size: 1.5rem;
 }
 
 .trackAndMuteContainer {
@@ -291,7 +334,7 @@ html {
 	display: grid;
     grid-template-columns: auto;
     grid-template-rows: min-content min-content min-content min-content min-content;
-    grid-template-areas: "version-area" "play-pause-area" "menu-area" "song-settings-area" "instrument-settings-area";
+    grid-template-areas: "version-area" "play-pause-area" "menu-area" "song-settings-area" "tab-controls-area";
 	grid-column-gap: 6px;
 }
 
@@ -299,7 +342,7 @@ html {
 .beepboxEditor .play-pause-area{ grid-area: play-pause-area; }
 .beepboxEditor .menu-area{ grid-area: menu-area; }
 .beepboxEditor .song-settings-area{ grid-area: song-settings-area; }
-.beepboxEditor .instrument-settings-area{ grid-area: instrument-settings-area; }
+.beepboxEditor .tab-controls-area{ grid-area: tab-controls-area; }
 
 .beepboxEditor .tip {
 	cursor: help;
@@ -1393,7 +1436,7 @@ html {
 	flex-direction: column;
 }
 
-.beepboxEditor .instrument-settings-area {
+.beepboxEditor .tab-controls-area {
 	display: flex;
 	flex-direction: column;
 }
@@ -1609,8 +1652,8 @@ li.select2-results__option[role=group] > strong:hover {
 		grid-template-rows: min-content min-content 1fr min-content;
 		grid-template-areas:
 			"play-pause-area play-pause-area"
-			"menu-area instrument-settings-area"
-			"song-settings-area instrument-settings-area"
+			"menu-area tab-controls-area"
+			"song-settings-area tab-controls-area"
 			"version-area version-area";
 		grid-column-gap: 8px;
 		margin: 0 4px;

--- a/editor/style.ts
+++ b/editor/style.ts
@@ -129,8 +129,48 @@ document.head.appendChild(HTML.style({ type: "text/css" }, `
 			<path d="M -1 76 L 30 76 L 30 1 L 33 -1 L 33 80 L -1 80 z" fill="rgba(0,0,0,0.7)"/> \
 			<rect x="-1" y="-1" width="19" height="80" fill="url(%23shadow)"/> \
 		</svg>'));
+	--internal-note-merge-symbol: var(--note-merge-symbol, url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.849555154,0,0,1,-2.515526041,0.883805424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.849555154,0,0,1,12.08684837,-5.479941038)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M9.397626,16.883805C9.397626,16.883805 14.602374,10.520059 14.602374,10.520059 " fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2" stroke-linecap="round"/> \
+	</svg>'));
+	--internal-note-bridge-symbol: var(--note-bridge-symbol, url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.521774032,0,0,1,-1.54496875,0.883805424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.521774032,0,0,1,16.683261204,-5.516939564)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M7.28871,16.883805C7.28871,16.883805 16.982323,16.883805 16.982323,16.883805 " fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+	</svg>'));
+	--internal-note-spread-symbol: var(--note-spread-symbol, url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.575289317,0,0,1,-1.703427083,2.883805424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,5.475782C5.77177,5.475782 5.77177,11.580539 5.77177,11.580539 " transform="matrix(0,1,-1,0,13.844224124,2.294529431)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(0,1,-1,0,12.844224124,2.997501424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(-1,0,0,-1,7.035455551,18.953098003)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,5.475782C5.77177,5.475782 5.77177,11.580539 5.77177,11.580539 " transform="matrix(0,-1,1,0,10.220330533,13.844224124)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(0,-1,1,0,11.220330533,13.141252131)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(1,0,0,1,17.029099106,-2.814344448)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.575289317,0,0,1,15.932826455,2.883805424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.575289317,0,0,1,7.114699686,2.883805424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+	</svg>'));
+	--internal-note-mirror-symbol: var(--note-mirror-symbol, url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 23" width="23" height="23"> \
+		<path d="M10.187072,5.368752C10.187072,5.368752 10.187072,18.627013 10.187072,18.627013 C10.187072,18.627013 2.649364,18.631248 2.649364,18.631248 C2.649364,18.631248 10.187072,5.368752 10.187072,5.368752 Z" fill="${ColorConfig.primaryText}" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M13.521935,2.108916C13.521935,2.108916 13.521935,19.15979 13.521935,19.15979 C13.521935,19.15979 21.059643,19.165236 21.059643,19.165236 C21.059643,19.165236 13.521935,2.108916 13.521935,2.108916 Z" transform="matrix(1,0,0,1,0,0)" fill="none" stroke="${ColorConfig.primaryText}" stroke-dasharray="2" stroke-dashoffset="-0.0000000000000014155343563970746"/> \
+	</svg>'));
+	--internal-note-flatten-symbol: var(--note-flatten-symbol, url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(2.17071376,0,0,1,-6.427466145,2.883805424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,5.475782C5.77177,5.475782 5.77177,11.580539 5.77177,11.580539 " transform="matrix(1,0,0,1,0,2)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(1,0,0,1,0.702971993,3)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(0,1,-1,0,16.658568572,8.808768572)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,5.475782C5.77177,5.475782 5.77177,11.580539 5.77177,11.580539 " transform="matrix(1,0,0,1,12.514859964,2)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(1,0,0,1,13.217831957,3)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M5.77177,11.580539C5.77177,11.580539 2.290663,8.099431 2.290663,8.099431 " transform="matrix(0,1,-1,0,29.173428536,8.808768572)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+	</svg>'));
+	--internal-note-split-symbol: var(--note-split-symbol, url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.444845809,0,0,1,-1.317184896,1.883805424)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0,1.69800195,-1,0,21.926220079,-1.66298398)" fill="none" stroke="${ColorConfig.primaryText}" stroke-dasharray="1"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,8.51278 14.022811,8.51278 " transform="matrix(0.88467456,0,0,0.998194604,4.632196761,1.825177311)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0.40696532,0,0,1,18.293202099,-5.857204894)" fill="none" stroke="${ColorConfig.primaryText}" stroke-width="2"/> \
+		<path d="M2.960992,16C2.960992,16 14.022811,16 14.022811,16 " transform="matrix(0,1.69800195,-1,0,34.418809989,-3.66298398)" fill="none" stroke="${ColorConfig.primaryText}" stroke-dasharray="1"/> \
+	</svg>'));
 }
-
 
 html {
 	scrollbar-color: var(--scrollbar-color, ${ColorConfig.uiWidgetBackground}) var(--scrollbar-background, ${ColorConfig.editorBackground});
@@ -267,6 +307,46 @@ div.tab-settings-radiodiv:hover {
 
 input.tab-settings-radio + div {
 	font-size: 1.5rem;
+}
+
+.beepboxEditor div.selectionOps-row {
+    display: flex;
+	margin-top: 10px;
+}
+
+.beepboxEditor div.selectionOps-row-inside {
+    display: flex;
+}
+
+.beepboxEditor div.selectionOps-action-controls {
+	padding: 0.3rem;
+}
+
+.beepboxEditor .selectionOps-action {
+    text-align: center;
+}
+
+.beepboxEditor .selectionOps-action-controls .checkbox-container {
+    text-align: left;
+	margin-top: 0.3rem;
+}
+
+.beepboxEditor div.selectionOps-action button.selectionOps-actionbutton {
+    height: calc(1.5 * var(--button-size));
+	width: calc(1.5 * var(--button-size));
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
+.beepboxEditor .noteOpMerge { background-image: var(--internal-note-merge-symbol) !important; }
+.beepboxEditor .noteOpBridge { background-image: var(--internal-note-bridge-symbol) !important; }
+.beepboxEditor .noteOpSpread { background-image: var(--internal-note-spread-symbol) !important; }
+.beepboxEditor .noteOpFlatten { background-image: var(--internal-note-flatten-symbol) !important; }
+.beepboxEditor .noteOpMirror { background-image: var(--internal-note-mirror-symbol) !important; }
+.beepboxEditor .noteOpSplit { background-image: var(--internal-note-split-symbol) !important; }
+
+.beepboxEditor div.selectionOps-action label {
+    padding-left: 0.3rem;
 }
 
 .trackAndMuteContainer {
@@ -1491,6 +1571,55 @@ input.tab-settings-radio + div {
   transform: scale(1.5);
 }
 
+.beepboxEditor checkbox-container,
+.beepboxEditor checkbox-container:before,
+.beepboxEditor checkbox-container:after {
+  box-sizing: border-box;
+}
+
+.beepboxEditor .checkbox-container {
+  color: ${ColorConfig.secondaryText};
+  line-height: 1.1;
+  display: grid;
+  grid-template-columns: 1em auto;
+  gap: 0.5em;
+}
+
+.beepboxEditor .checkbox-container--disabled {
+  color: ${ColorConfig.uiWidgetBackground};
+  cursor: not-allowed;
+}
+
+.beepboxEditor .checkbox-container input[type="checkbox"] {
+  /* Remove most native input styles */
+  -webkit-appearance: none;
+  appearance: none;
+  /* Not removed via appearance */
+  margin: 0;
+
+  font: inherit;
+  color: currentColor;
+  background-color: ${ColorConfig.uiWidgetBackground};
+  width: 1.15em;
+  height: 1.15em;
+  transform: translateY(-0.075em);
+
+  display: grid;
+  place-content: center;
+}
+
+.beepboxEditor .checkbox-container input[type="checkbox"]:checked::before {
+  content: "✓";
+  width: 0.8em;
+  height: 1.1em;
+  color: ${ColorConfig.primaryText};
+}
+
+.beepboxEditor .checkbox-container input[type="checkbox"]:disabled {
+  color: ${ColorConfig.uiWidgetBackground};
+  cursor: default;
+}
+
 .beepboxEditor input[type=range] {
 	-webkit-appearance: none;
 	color: inherit;
@@ -1501,7 +1630,7 @@ input.tab-settings-radio + div {
 	cursor: pointer;
 	background: none;
 	touch-action: pan-y;
-  position: relative;
+    position: relative;
 }
 .beepboxEditor input[type=range]:focus {
 	outline: none;

--- a/synth/SynthConfig.ts
+++ b/synth/SynthConfig.ts
@@ -506,6 +506,13 @@ function loadScript(url: string): Promise<void> {
     return result;
 }
 
+/** Specially-handled lowercase sample urls for ease-of-use. */
+export const bundledSamplePacks = {
+    legacy: "legacysamples",
+    nintaribox: "nintariboxsamples",
+    mariopaintbox: "mariopaintboxsamples"
+}
+
 export function loadBuiltInSamples(set: number): void {
     const defaultIndex: number = 0;
     const defaultIntegratedSamples: Float32Array = Config.chipWaves[defaultIndex].samples;
@@ -603,7 +610,7 @@ export function loadBuiltInSamples(set: number): void {
 	    Config.chipWaves[chipWaveIndex] = integratedChipWave;
 	    Config.chipWaves.dictionary[chipWave.name] = rawChipWave;
 	    sampleLoadingState.statusTable[chipWaveIndex] = SampleLoadingStatus.loading;
-	    sampleLoadingState.urlTable[chipWaveIndex] = "legacySamples";
+	    sampleLoadingState.urlTable[chipWaveIndex] = bundledSamplePacks.legacy;
 	}
 
 	loadScript("samples.js")
@@ -730,7 +737,7 @@ export function loadBuiltInSamples(set: number): void {
 	    Config.chipWaves[chipWaveIndex] = integratedChipWave;
 	    Config.chipWaves.dictionary[chipWave.name] = rawChipWave;
 	    sampleLoadingState.statusTable[chipWaveIndex] = SampleLoadingStatus.loading;
-	    sampleLoadingState.urlTable[chipWaveIndex] = "nintariboxSamples";
+	    sampleLoadingState.urlTable[chipWaveIndex] = bundledSamplePacks.nintaribox;
 	}
 
 	loadScript("nintaribox_samples.js")
@@ -792,7 +799,7 @@ export function loadBuiltInSamples(set: number): void {
 	    Config.chipWaves[chipWaveIndex] = integratedChipWave;
 	    Config.chipWaves.dictionary[chipWave.name] = rawChipWave;
 	    sampleLoadingState.statusTable[chipWaveIndex] = SampleLoadingStatus.loading;
-	    sampleLoadingState.urlTable[chipWaveIndex] = "marioPaintboxSamples";
+	    sampleLoadingState.urlTable[chipWaveIndex] = bundledSamplePacks.mariopaintbox;
 	}
 
 	loadScript("mario_paintbox_samples.js")

--- a/synth/synth.ts
+++ b/synth/synth.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2022 John Nesky and contributing authors, distributed under the MIT license, see accompanying the LICENSE.md file.
 
-import { startLoadingSample, sampleLoadingState, SampleLoadingState, sampleLoadEvents, SampleLoadedEvent, SampleLoadingStatus, loadBuiltInSamples, Dictionary, DictionaryArray, toNameMap, FilterType, SustainType, EnvelopeType, InstrumentType, EffectType, EnvelopeComputeIndex, Transition, Unison, Chord, Vibrato, Envelope, AutomationTarget, Config, getDrumWave, drawNoiseSpectrum, getArpeggioPitchIndex, performIntegralOld, getPulseWidthRatio, effectsIncludeTransition, effectsIncludeChord, effectsIncludePitchShift, effectsIncludeDetune, effectsIncludeVibrato, effectsIncludeNoteFilter, effectsIncludeDistortion, effectsIncludeBitcrusher, effectsIncludePanning, effectsIncludeChorus, effectsIncludeEcho, effectsIncludeReverb, OperatorWave } from "./SynthConfig";
+import { startLoadingSample, sampleLoadingState, SampleLoadingState, sampleLoadEvents, SampleLoadedEvent, SampleLoadingStatus, loadBuiltInSamples, Dictionary, DictionaryArray, toNameMap, FilterType, SustainType, EnvelopeType, InstrumentType, EffectType, EnvelopeComputeIndex, Transition, Unison, Chord, Vibrato, Envelope, AutomationTarget, Config, getDrumWave, drawNoiseSpectrum, getArpeggioPitchIndex, performIntegralOld, getPulseWidthRatio, effectsIncludeTransition, effectsIncludeChord, effectsIncludePitchShift, effectsIncludeDetune, effectsIncludeVibrato, effectsIncludeNoteFilter, effectsIncludeDistortion, effectsIncludeBitcrusher, effectsIncludePanning, effectsIncludeChorus, effectsIncludeEcho, effectsIncludeReverb, OperatorWave, bundledSamplePacks } from "./SynthConfig";
 import { Preset, EditorConfig } from "../editor/EditorConfig";
 import { scaleElementsByFactor, inverseRealFourierTransform } from "./FFT";
 import { Deque } from "./Deque";
@@ -3819,21 +3819,21 @@ export class Song {
                         sampleLoadingState.samplesLoaded
                     ));
                     for (const url of compressed_array) {
-                        if (url.toLowerCase() === "legacysamples") {
+                        if (url.toLowerCase() === bundledSamplePacks.legacy) {
                             if (!willLoadLegacySamples) {
                                 willLoadLegacySamples = true;
                                 customSampleUrls.push(url);
                                 loadBuiltInSamples(0);
                             }
                         } 
-                        else if (url.toLowerCase() === "nintariboxsamples") {
+                        else if (url.toLowerCase() === bundledSamplePacks.nintaribox) {
                             if (!willLoadNintariboxSamples) {
                                 willLoadNintariboxSamples = true;
                                 customSampleUrls.push(url);
                                 loadBuiltInSamples(1);
                             }
                         }
-                        else if (url.toLowerCase() === "mariopaintboxsamples") {
+                        else if (url.toLowerCase() === bundledSamplePacks.mariopaintbox) {
                             if (!willLoadMarioPaintboxSamples) {
                                 willLoadMarioPaintboxSamples = true;
                                 customSampleUrls.push(url);
@@ -4414,11 +4414,11 @@ export class Song {
                     }
                 }
                 else if (fromGoldBox && !beforeFour && beforeSix) {
-                    if (document.URL.substring(document.URL.length - 13).toLowerCase() != "legacysamples") {
+                    if (document.URL.substring(document.URL.length - 13).toLowerCase() != bundledSamplePacks.legacy) {
                             if (!willLoadLegacySamplesForOldSongs) {
                                 willLoadLegacySamplesForOldSongs = true;
                                 Config.willReloadForCustomSamples = true;
-                                EditorConfig.customSamples = ["legacySamples"];
+                                EditorConfig.customSamples = [bundledSamplePacks.legacy];
                                 loadBuiltInSamples(0);
                             }
                     }
@@ -5104,11 +5104,11 @@ export class Song {
                     //is it more useful to save base64 characters or url length?
                     const chipWaveForCompat = base64CharCodeToInt[compressed.charCodeAt(charIndex++)];
                     if ((chipWaveForCompat + 62) > 85) {
-                        if (document.URL.substring(document.URL.length - 13).toLowerCase() != "legacysamples") {
+                        if (document.URL.substring(document.URL.length - 13).toLowerCase() != bundledSamplePacks.legacy) {
                             if (!willLoadLegacySamplesForOldSongs) {
                                 willLoadLegacySamplesForOldSongs = true;
                                 Config.willReloadForCustomSamples = true;
-                                EditorConfig.customSamples = ["legacySamples"];
+                                EditorConfig.customSamples = [bundledSamplePacks.legacy];
                                 loadBuiltInSamples(0);
                             }
                         }
@@ -6219,21 +6219,21 @@ export class Song {
                 const customSampleUrls: string[] = [];
                 const customSamplePresets: Preset[] = [];
                 for (const url of customSamples) {
-                    if (url.toLowerCase() === "legacysamples") {
+                    if (url.toLowerCase() === bundledSamplePacks.legacy) {
                         if (!willLoadLegacySamples) {
                             willLoadLegacySamples = true;
                             customSampleUrls.push(url);
                             loadBuiltInSamples(0);
                         }
                     } 
-                    else if (url.toLowerCase() === "nintariboxsamples") {
+                    else if (url.toLowerCase() === bundledSamplePacks.nintaribox) {
                         if (!willLoadNintariboxSamples) {
                             willLoadNintariboxSamples = true;
                             customSampleUrls.push(url);
                             loadBuiltInSamples(1);
                         }
                     }
-                    else if (url.toLowerCase() === "mariopaintboxsamples") {
+                    else if (url.toLowerCase() === bundledSamplePacks.mariopaintbox) {
                         if (!willLoadMarioPaintboxSamples) {
                             willLoadMarioPaintboxSamples = true;
                             customSampleUrls.push(url);
@@ -6500,7 +6500,7 @@ export class Song {
                 Song._restoreChipWaveListToDefault();
 
                 loadBuiltInSamples(0);
-                EditorConfig.customSamples = ["legacySamples"];
+                EditorConfig.customSamples = [bundledSamplePacks.legacy];
             } else {
                 // We don't need to load the legacy samples, but we may have
                 // leftover samples in memory. If we do, clear them.

--- a/synth/synth.ts
+++ b/synth/synth.ts
@@ -2899,6 +2899,10 @@ export class Song {
         }
     }
 
+    public get partsPerPattern() {
+        return this.beatsPerBar * Config.partsPerBeat;
+    }
+
     // Returns the ideal new note volume when dragging (max volume for a normal note, a "neutral" value for mod notes based on how they work)
     public getNewNoteVolume = (isMod: boolean, modChannel?: number, modInstrument?: number, modCount?: number): number => {
         if (!isMod || modChannel == undefined || modInstrument == undefined || modCount == undefined)

--- a/tsconfig_synth_only.json
+++ b/tsconfig_synth_only.json
@@ -14,7 +14,7 @@
 		"strictBindCallApply": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
-		"noUnusedLocals": true,
+		"noUnusedLocals": false,
 		"lib": [
 			"DOM",
 			"ES5",

--- a/website/player/index.html
+++ b/website/player/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<link rel="icon" type="image/x-icon" href="./favicon.ico" />
+	<link rel="icon" type="image/x-icon" href="../favicon.ico" />
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>UltraBox Song Player</title> 


### PR DESCRIPTION
Most of this just refactors magic strings to one place. Also,

- switch to display: "none" to fix https://github.com/ultraabox/ultrabox_typescript/issues/251
- changes "Mute Channel" and Solo to read as un/Mute and un/Solo Channel since they toggle on click