### PR TITLE
Fix #288, clear fx cache when seeking across bars in player

### DIFF
--- a/editor/SongDocument.ts
+++ b/editor/SongDocument.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2022 John Nesky and contributing authors, distributed under the MIT license, see accompanying the LICENSE.md file.
 
 import {Config} from "../synth/SynthConfig";
-import {isMobile} from "./EditorConfig";
+import {EditorConfig, isMobile} from "./EditorConfig";
 import {Pattern, Channel, Song, Synth} from "../synth/synth";
 import { SongRecovery, generateUid, errorAlert } from "./SongRecovery";
 import { ColorConfig } from "./ColorConfig";
@@ -84,6 +84,9 @@ export class SongDocument {
 				setDefaultInstruments(this.song);
 				this.song.scale = this.prefs.defaultScale;
 			}
+			const updateDocumentTitle = () => document.title = this.song.title + " - " + EditorConfig.versionDisplayName;
+			this.song.titleNotifier.push(updateDocumentTitle);
+			updateDocumentTitle();
 		} catch (error) {
 			errorAlert(error);
 		}

--- a/player/main.ts
+++ b/player/main.ts
@@ -673,6 +673,7 @@ function onKeyPressed(event: KeyboardEvent): void {
 	switch (event.keyCode) {
 		case 70: // first bar
 			synth.playhead = 0;
+			synth.resetEffects();
 			synth.computeLatestModValues();
 			renderPlayhead();
 			event.preventDefault();
@@ -684,12 +685,14 @@ function onKeyPressed(event: KeyboardEvent): void {
 			break;
 		case 219: // left brace
 			synth.goToPrevBar();
+			synth.resetEffects();
 			synth.computeLatestModValues();
 			renderPlayhead();
 			event.preventDefault();
 			break;
 		case 221: // right brace
 			synth.goToNextBar();
+			synth.resetEffects();
 			synth.computeLatestModValues();
 			renderPlayhead();
 			event.preventDefault();

--- a/synth/synth.ts
+++ b/synth/synth.ts
@@ -2855,6 +2855,7 @@ export class Song {
     private static readonly _variant = 0x75; //"u" ~ ultrabox
 
     public title: string;
+    public titleNotifier: Function[] = [];
     public scale: number;
     public scaleCustom: boolean[] = [];
     public key: number;
@@ -3019,7 +3020,7 @@ export class Song {
         this.patternInstruments = false;
 
         this.title = "Untitled";
-        document.title = this.title + " - " + EditorConfig.versionDisplayName;
+        this.titleNotifier.forEach(o => o());
 
         if (andResetChannels) {
             this.pitchChannelCount = 3;
@@ -3901,7 +3902,7 @@ export class Song {
                 // Length of song name string
                 var songNameLength = (base64CharCodeToInt[compressed.charCodeAt(charIndex++)] << 6) + base64CharCodeToInt[compressed.charCodeAt(charIndex++)];
                 this.title = decodeURIComponent(compressed.substring(charIndex, charIndex + songNameLength));
-                document.title = this.title + " - " + EditorConfig.versionDisplayName;
+                this.titleNotifier.forEach(o => o());
 
                 charIndex += songNameLength;
             } break;

--- a/synth/synth.ts
+++ b/synth/synth.ts
@@ -11425,7 +11425,10 @@ export class Synth {
             const data: Float32Array = synth.tempMonoInstrumentSampleBuffer!;
             const wave: Float32Array = instrumentState.wave!;
             const volumeScale: number = instrumentState.volumeScale;
-            const waveLength: number = (aliases && instrumentState.type == 8) ? wave.length : wave.length - 1;
+
+            // For all but aliasing custom chip, the first sample is duplicated at the end, so don't double-count it.
+            const waveLength: number = (aliases && instrumentState.type == InstrumentType.customChipWave) ? wave.length : wave.length - 1;
+
             let chipWaveLoopEnd: number = Math.max(0, Math.min(waveLength, instrumentState.chipWaveLoopEnd));
             let chipWaveLoopStart: number = Math.max(0, Math.min(chipWaveLoopEnd - 1, instrumentState.chipWaveLoopStart));
 			// @TODO: This is where to set things up for the release loop mode.
@@ -11751,7 +11754,7 @@ export class Synth {
         const wave: Float32Array = instrumentState.wave!;
         const volumeScale = instrumentState.volumeScale;
 
-        const waveLength = (aliases && instrumentState.type == 8) ? wave.length : wave.length - 1;
+        const waveLength = (aliases && instrumentState.type == InstrumentType.customChipWave) ? wave.length : wave.length - 1;
 
         const unisonSign: number = tone.specialIntervalExpressionMult * instrumentState.unisonSign;
         if (instrumentState.unisonVoices == 1 && instrumentState.unisonSpread == 0 && !instrumentState.chord!.customInterval) tone.phases[1] = tone.phases[0];


### PR DESCRIPTION
- Fixed bug #288 (synth should not set document.title)
- Seeking in the player no longer carries over the old effects buffer erroneously (it still does for dragging, by necessity). This was a bug mentioned verbally over socials
- Fixed a bug mentioned by Slarmoo where the enum value was off by 1 thanks to hardcoding the numeric literal instead of actually using the enum. The enum got updated, bumping the intended value to 9 and there was now a mismatch.