### PR TITLE
Improve mute editor + refactor

### DIFF
--- a/editor/AddSamplesPrompt.ts
+++ b/editor/AddSamplesPrompt.ts
@@ -1,5 +1,5 @@
 import { HTML, SVG } from "imperative-html/dist/esm/elements-strict";
-import { Dictionary, Config } from "../synth/SynthConfig";
+import { Dictionary, Config, bundledSamplePacks } from "../synth/SynthConfig";
 import { clamp, parseFloatWithDefault, parseIntWithDefault } from "../synth/synth";
 import { ColorConfig } from "./ColorConfig";
 import { EditorConfig } from "./EditorConfig";
@@ -49,13 +49,13 @@ export class AddSamplesPrompt {
     private readonly _description: HTMLDivElement = div(
         div({ style: "margin-bottom: 0.5em; -webkit-user-select: text; -moz-user-select: text; -ms-user-select: text; user-select: text; cursor: text;" },
             "In order to use the old UltraBox samples, you should add ",
-            code("legacySamples"),
+            code(bundledSamplePacks.legacy),
             " for the PaandorasBox Samples.",
             p({}),
             "You can also use ",
-            code("nintariboxSamples"),
+            code(bundledSamplePacks.nintaribox),
             " and ",
-            code("marioPaintboxSamples"),
+            code(bundledSamplePacks.mariopaintbox),
             " for more built-in sample packs."
         ),
         div({ style: "margin-bottom: 0.5em;" },
@@ -443,10 +443,10 @@ export class AddSamplesPrompt {
         const parsedEntries: SampleEntry[] = [];
         for (const url of urls) {
             if (url === "") continue;
-            if (url.toLowerCase() === "legacysamples") {
+            if (url.toLowerCase() === bundledSamplePacks.legacy) {
                 if (!useLegacySamples) {
                     parsedEntries.push({
-                        url: "legacySamples",
+                        url: bundledSamplePacks.legacy,
                         sampleRate: 44100,
                         rootKey: 60,
                         percussion: false,
@@ -458,10 +458,10 @@ export class AddSamplesPrompt {
                     });
                 }
                 useLegacySamples = true;
-            } else if (url.toLowerCase() === "nintariboxsamples") {
+            } else if (url.toLowerCase() === bundledSamplePacks.nintaribox) {
                 if (!useNintariboxSamples) {
                     parsedEntries.push({
-                        url: "nintariboxSamples",
+                        url: bundledSamplePacks.nintaribox,
                         sampleRate: 44100,
                         rootKey: 60,
                         percussion: false,
@@ -473,10 +473,10 @@ export class AddSamplesPrompt {
                     });
                 }
                 useNintariboxSamples = true;
-            } else if (url.toLowerCase() === "mariopaintboxsamples") {
+            } else if (url.toLowerCase() === bundledSamplePacks.mariopaintbox) {
                 if (!useMarioPaintboxSamples) {
                     parsedEntries.push({
-                        url: "marioPaintboxSamples",
+                        url: bundledSamplePacks.mariopaintbox,
                         sampleRate: 44100,
                         rootKey: 60,
                         percussion: false,
@@ -589,11 +589,7 @@ export class AddSamplesPrompt {
         const chipWaveLoopMode: number | null = entry.chipWaveLoopMode;
         const chipWavePlayBackwards: boolean = entry.chipWavePlayBackwards;
         const urlInLowerCase: string = url.toLowerCase();
-        const isBundledSamplePack: boolean = (
-            urlInLowerCase === "legacysamples"
-            || urlInLowerCase === "nintariboxsamples"
-            || urlInLowerCase === "mariopaintboxsamples"
-        );
+        const isBundledSamplePack: boolean = Object.keys(bundledSamplePacks).includes(urlInLowerCase);
         const options: string[] = [];
         if (sampleRate !== 44100) options.push("s" + sampleRate);
         if (rootKey !== 60) options.push("r" + rootKey);

--- a/editor/MuteEditor.ts
+++ b/editor/MuteEditor.ts
@@ -93,7 +93,7 @@ export class MuteEditor {
 		this._channelDropDownChannel = Math.floor(Math.min(this._buttons.length, Math.max(0, parseInt(this._channelDropDown.style.getPropertyValue("top")) / ChannelRow.patternHeight)));
 		this._doc.muteEditorChannel = this._channelDropDownChannel;
 
-		this._channelNameDisplay.style.setProperty("display", "");
+		this._channelNameDisplay.style.setProperty("display", "none");
 
 		// Check if channel is at limit, in which case another can't be inserted
 		if ((this._channelDropDownChannel < this._doc.song.pitchChannelCount && this._doc.song.pitchChannelCount == Config.pitchChannelCountMax)
@@ -118,6 +118,9 @@ export class MuteEditor {
 		else {
 			this._channelDropDown.options[2].disabled = false;
 		}
+
+		this._channelDropDown.options[3].text = this._doc.song.channels[this._channelDropDownChannel].muted ? "Unmute Channel" : "Mute Channel";
+		this._channelDropDown.options[4].text = this._isChannelSolo() ? "Un-solo Channel" : "Solo Channel";
 
 		// Also, can't delete the last pitch channel.
 		if (this._doc.song.pitchChannelCount == 1 && this._channelDropDownChannel == 0) {
@@ -159,22 +162,9 @@ export class MuteEditor {
 				break;
 			case "chnSolo": {
 				// Check for any channel not matching solo pattern
-				let shouldSolo: boolean = false;
-				for (let channel: number = 0; channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount; channel++) {
-					if (this._doc.song.channels[channel].muted == (channel == this._channelDropDownChannel)) {
-						shouldSolo = true;
-						channel = this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount;
-					}
-				}
-				if (shouldSolo) {
-					for (let channel: number = 0; channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount; channel++) {
-						this._doc.song.channels[channel].muted = (channel != this._channelDropDownChannel);
-					}
-				}
-				else {
-					for (let channel: number = 0; channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount; channel++) {
-						this._doc.song.channels[channel].muted = false;
-					}
+				let isSolo = this._isChannelSolo();
+				for (let channel = 0; channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount; channel++) {
+					this._doc.song.channels[channel].muted = isSolo ? false : (channel !== this._channelDropDownChannel);
 				}
 				this.render();
 				break;
@@ -281,6 +271,16 @@ export class MuteEditor {
 			default:
 				break;
 		}
+	}
+
+	private _isChannelSolo = () => {
+		for (let channel = 0; channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount; channel++) {
+			if (channel !== this._channelDropDownChannel && !this._doc.song.channels[channel].muted) {
+				return false;
+			}
+		}
+
+		return !this._doc.song.channels[this._channelDropDownChannel].muted;
 	}
 
 	public render(): void {

--- a/editor/PatternEditor.ts
+++ b/editor/PatternEditor.ts
@@ -240,7 +240,7 @@ export class PatternEditor {
         this._cursor.part =
             Math.floor(
                 Math.max(0,
-                    Math.min(this._doc.song.beatsPerBar * Config.partsPerBeat - minDivision, this._cursor.exactPart)
+                    Math.min(this._doc.song.partsPerPattern - minDivision, this._cursor.exactPart)
                 )
                 / minDivision) * minDivision;
 
@@ -432,7 +432,7 @@ export class PatternEditor {
             }
             this._cursor.end = this._cursor.start + defaultLength;
             let forceStart: number = 0;
-            let forceEnd: number = this._doc.song.beatsPerBar * Config.partsPerBeat;
+            let forceEnd: number = this._doc.song.partsPerPattern;
             if (this._cursor.prevNote != null) {
                 forceStart = this._cursor.prevNote.end;
             }
@@ -630,8 +630,8 @@ export class PatternEditor {
             // note flash
             for (var i = 0; i < noteFlashElements.length; i++) {
                 var element: SVGPathElement = noteFlashElements[i];
-                const noteStart: number = Number(element.getAttribute("note-start"))/(this._doc.song.beatsPerBar * Config.partsPerBeat)
-                const noteEnd: number = Number(element.getAttribute("note-end"))/(this._doc.song.beatsPerBar * Config.partsPerBeat)
+                const noteStart: number = Number(element.getAttribute("note-start"))/(this._doc.song.partsPerPattern)
+                const noteEnd: number = Number(element.getAttribute("note-end"))/(this._doc.song.partsPerPattern)
                 if ((modPlayhead>=noteStart)&&this._doc.prefs.notesFlashWhenPlayed) {
                     const dist = noteEnd-noteStart
                     element.style.opacity = String((1-(((modPlayhead-noteStart)-(dist/2))/(dist/2))))
@@ -1748,10 +1748,10 @@ export class PatternEditor {
             const minDivision: number = this._getMinDivision();
             const currentPart: number = this._snapToMinDivision(this._mouseX / this._partWidth);
             if (this._draggingStartOfSelection) {
-                sequence.append(new ChangePatternSelection(this._doc, Math.max(0, Math.min(this._doc.song.beatsPerBar * Config.partsPerBeat, currentPart)), this._doc.selection.patternSelectionEnd));
+                sequence.append(new ChangePatternSelection(this._doc, Math.max(0, Math.min(this._doc.song.partsPerPattern, currentPart)), this._doc.selection.patternSelectionEnd));
                 this._updateSelection();
             } else if (this._draggingEndOfSelection) {
-                sequence.append(new ChangePatternSelection(this._doc, this._doc.selection.patternSelectionStart, Math.max(0, Math.min(this._doc.song.beatsPerBar * Config.partsPerBeat, currentPart))));
+                sequence.append(new ChangePatternSelection(this._doc, this._doc.selection.patternSelectionStart, Math.max(0, Math.min(this._doc.song.partsPerPattern, currentPart))));
                 this._updateSelection();
             } else if (this._draggingSelectionContents) {
                 const pattern: Pattern | null = this._doc.getCurrentPattern(this._barOffset);
@@ -1844,7 +1844,7 @@ export class PatternEditor {
                     }
 
                     let defaultLength: number = minDivision;
-                    for (let i: number = minDivision; i <= this._doc.song.beatsPerBar * Config.partsPerBeat; i += minDivision) {
+                    for (let i: number = minDivision; i <= this._doc.song.partsPerPattern; i += minDivision) {
                         if (minDivision == 1) {
                             if (i < 5) {
                                 // Allow small lengths.
@@ -1898,7 +1898,7 @@ export class PatternEditor {
                     }
                     const continuesLastPattern: boolean = (start < 0 && this._doc.channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount);
                     if (start < 0) start = 0;
-                    if (end > this._doc.song.beatsPerBar * Config.partsPerBeat) end = this._doc.song.beatsPerBar * Config.partsPerBeat;
+                    if (end > this._doc.song.partsPerPattern) end = this._doc.song.partsPerPattern;
 
                     if (start < end) {
                         sequence.append(new ChangeEnsurePatternExists(this._doc, this._doc.channel, this._doc.bar));
@@ -1942,7 +1942,7 @@ export class PatternEditor {
                     let shiftedTime: number = Math.round((this._cursor.curNote.start + shiftedPin.time + shift) / minDivision) * minDivision;
                     const continuesLastPattern: boolean = (shiftedTime < 0.0 && this._doc.channel < this._doc.song.pitchChannelCount + this._doc.song.noiseChannelCount);
                     if (shiftedTime < 0) shiftedTime = 0;
-                    if (shiftedTime > this._doc.song.beatsPerBar * Config.partsPerBeat) shiftedTime = this._doc.song.beatsPerBar * Config.partsPerBeat;
+                    if (shiftedTime > this._doc.song.partsPerPattern) shiftedTime = this._doc.song.partsPerPattern;
 
                     if (this._pattern == null) throw new Error();
 
@@ -2013,7 +2013,7 @@ export class PatternEditor {
                     if (this._doc.song.getChannelIsMod(this._doc.channel) && this.controlMode) {
                         // Link bend to the next note over
                         if (bendPart >= this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time) {
-                            if (this._cursor.curNote.start + this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time < this._doc.song.beatsPerBar * Config.partsPerBeat) {
+                            if (this._cursor.curNote.start + this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time < this._doc.song.partsPerPattern) {
                                 for (const note of this._pattern!.notes) {
                                     if (note.start == this._cursor.curNote.start + this._cursor.curNote.pins[this._cursor.curNote.pins.length - 1].time && note.pitches[0] == this._cursor.curNote.pitches[0]) {
                                         sequence.append(new ChangeSizeBend(this._doc, note, note.pins[0].time, bendSize, bendInterval, this.shiftMode));
@@ -2049,7 +2049,7 @@ export class PatternEditor {
 
                                 if (prevPattern != null && prevPattern.instruments[0] == this._pattern!.instruments[0]) {
                                     for (const note of prevPattern.notes) {
-                                        if (note.end == this._doc.song.beatsPerBar * Config.partsPerBeat && note.pitches[0] == this._cursor.curNote.pitches[0]) {
+                                        if (note.end == this._doc.song.partsPerPattern && note.pitches[0] == this._cursor.curNote.pitches[0]) {
                                             sequence.append(new ChangeSizeBend(this._doc, note, note.pins[note.pins.length - 1].time, bendSize, bendInterval, this.shiftMode));
                                         }
                                     }
@@ -2082,7 +2082,7 @@ export class PatternEditor {
                         bendEnd = currentPart;
                     }
                     if (bendEnd < 0) bendEnd = 0;
-                    if (bendEnd > this._doc.song.beatsPerBar * Config.partsPerBeat) bendEnd = this._doc.song.beatsPerBar * Config.partsPerBeat;
+                    if (bendEnd > this._doc.song.partsPerPattern) bendEnd = this._doc.song.partsPerPattern;
                     if (bendEnd > this._cursor.curNote.end) {
                         sequence.append(new ChangeNoteTruncate(this._doc, this._pattern, this._cursor.curNote.start, bendEnd, this._cursor.curNote));
                     }
@@ -2292,7 +2292,7 @@ export class PatternEditor {
 
         this._editorWidth = this.container.clientWidth;
         this._editorHeight = this.container.clientHeight;
-        this._partWidth = this._editorWidth / (this._doc.song.beatsPerBar * Config.partsPerBeat);
+        this._partWidth = this._editorWidth / (this._doc.song.partsPerPattern);
         this._octaveOffset = (this._doc.channel >= this._doc.song.pitchChannelCount) ? 0 : this._doc.song.channels[this._doc.channel].octave * Config.pitchesPerOctave;
 
         if (this._doc.song.getChannelIsNoise(this._doc.channel)) {

--- a/editor/Selection.ts
+++ b/editor/Selection.ts
@@ -329,7 +329,7 @@ export class Selection {
         }
 
         const selectionCopy: SelectionCopy = {
-            "partDuration": this.patternSelectionActive ? this.patternSelectionEnd - this.patternSelectionStart : this._doc.song.beatsPerBar * Config.partsPerBeat,
+            "partDuration": this.patternSelectionActive ? this.patternSelectionEnd - this.patternSelectionStart : this._doc.song.partsPerPattern,
             "channels": channels,
         };
         window.localStorage.setItem("selectionCopy", JSON.stringify(selectionCopy));

--- a/editor/SongPerformance.ts
+++ b/editor/SongPerformance.ts
@@ -126,7 +126,7 @@ export class SongPerformance {
 	}
 	
 	private _getCurrentPlayheadPart(): number {
-		const currentPart: number = this._doc.synth.playhead * this._doc.song.beatsPerBar * Config.partsPerBeat;
+		const currentPart: number = this._doc.synth.playhead * this._doc.song.partsPerPattern;
 		if (this._doc.prefs.snapRecordedNotesToRhythm) {
 			const minDivision: number = this._getMinDivision();
 			return Math.round(currentPart / minDivision) * minDivision;
@@ -167,7 +167,7 @@ export class SongPerformance {
 			return false;
 		}
 		
-		const partsPerBar: number = this._doc.song.beatsPerBar * Config.partsPerBeat;
+		const partsPerBar: number = this._doc.song.partsPerPattern;
 		const oldPart: number = this._playheadPart % partsPerBar;
 		const oldBar: number = Math.floor(this._playheadPart / partsPerBar);
 		const oldPlayheadPart: number = this._playheadPart;
@@ -269,7 +269,7 @@ export class SongPerformance {
 			return false;
 		}
 		
-		const partsPerBar: number = this._doc.song.beatsPerBar * Config.partsPerBeat;
+		const partsPerBar: number = this._doc.song.partsPerPattern;
 		const oldPart: number = this._bassPlayheadPart % partsPerBar;
 		const oldBar: number = Math.floor(this._bassPlayheadPart / partsPerBar);
 		const oldPlayheadPart: number = this._bassPlayheadPart;

--- a/editor/changes.ts
+++ b/editor/changes.ts
@@ -3588,7 +3588,7 @@ export class ChangeMoveNotesSideways extends ChangeGroup {
     constructor(doc: SongDocument, beatsToMove: number, strategy: string) {
         super();
         let partsToMove: number = Math.round((beatsToMove % doc.song.beatsPerBar) * Config.partsPerBeat);
-        if (partsToMove < 0) partsToMove += doc.song.beatsPerBar * Config.partsPerBeat;
+        if (partsToMove < 0) partsToMove += doc.song.partsPerPattern;
         if (partsToMove == 0.0) return;
 
         switch (strategy) {
@@ -3667,7 +3667,7 @@ export class ChangeBeatsPerBar extends ChangeGroup {
                         const sequence: ChangeSequence = new ChangeSequence();
                         for (let i: number = 0; i < doc.song.getChannelCount(); i++) {
                             for (let j: number = 0; j < doc.song.channels[i].patterns.length; j++) {
-                                sequence.append(new ChangeNoteTruncate(doc, doc.song.channels[i].patterns[j], newValue * Config.partsPerBeat, doc.song.beatsPerBar * Config.partsPerBeat, null, true));
+                                sequence.append(new ChangeNoteTruncate(doc, doc.song.channels[i].patterns[j], newValue * Config.partsPerBeat, doc.song.partsPerPattern, null, true));
                             }
                         }
                     }
@@ -4424,8 +4424,8 @@ export class ChangeDragSelectedNotes extends ChangeSequence {
 
         const oldStart: number = doc.selection.patternSelectionStart;
         const oldEnd: number = doc.selection.patternSelectionEnd;
-        const newStart: number = Math.max(0, Math.min(doc.song.beatsPerBar * Config.partsPerBeat, oldStart + parts));
-        const newEnd: number = Math.max(0, Math.min(doc.song.beatsPerBar * Config.partsPerBeat, oldEnd + parts));
+        const newStart: number = Math.max(0, Math.min(doc.song.partsPerPattern, oldStart + parts));
+        const newEnd: number = Math.max(0, Math.min(doc.song.partsPerPattern, oldEnd + parts));
         if (newStart == newEnd) {
             // Just erase the current contents of the selection:
             this.append(new ChangeNoteTruncate(doc, pattern, oldStart, oldEnd, null, true));

--- a/player/main.ts
+++ b/player/main.ts
@@ -481,7 +481,7 @@ function renderPlayhead(): void {
 		if (notesFlashWhenPlayed) {
 			const playheadBar: number = Math.floor(synth.playhead);
 			const modPlayhead: number = synth.playhead - playheadBar;
-			const partsPerBar: number = synth.song.beatsPerBar * Config.partsPerBeat;
+			const partsPerBar: number = synth.song.partsPerPattern;
 			const noteFlashElementsForThisBar: SVGPathElement[] = noteFlashElementsPerBar[playheadBar];
 
 			if (noteFlashElementsForThisBar != null && playheadBar !== currentNoteFlashBar) {
@@ -550,7 +550,7 @@ function renderTimeline(): void {
 	timeline.style.height = timelineHeight + "px";
 		
 	const barWidth: number = timelineWidth / synth.song.barCount;
-	const partWidth: number = barWidth / (synth.song.beatsPerBar * Config.partsPerBeat);
+	const partWidth: number = barWidth / (synth.song.partsPerPattern);
 
 		const wavePitchHeight: number = (timelineHeight-1) / windowPitchCount;
 		const drumPitchHeight: number =  (timelineHeight-1) / Config.drumCount;

--- a/synth/SynthConfig.ts
+++ b/synth/SynthConfig.ts
@@ -512,6 +512,13 @@ function loadScript(url: string): Promise<void> {
     return result;
 }
 
+/** Specially-handled lowercase sample urls for ease-of-use. */
+export const bundledSamplePacks = {
+    legacy: "legacysamples",
+    nintaribox: "nintariboxsamples",
+    mariopaintbox: "mariopaintboxsamples"
+}
+
 export function loadBuiltInSamples(set: number): void {
     const defaultIndex: number = 0;
     const defaultIntegratedSamples: Float32Array = Config.chipWaves[defaultIndex].samples;
@@ -609,7 +616,7 @@ export function loadBuiltInSamples(set: number): void {
 	    Config.chipWaves[chipWaveIndex] = integratedChipWave;
 	    Config.chipWaves.dictionary[chipWave.name] = rawChipWave;
 	    sampleLoadingState.statusTable[chipWaveIndex] = SampleLoadingStatus.loading;
-	    sampleLoadingState.urlTable[chipWaveIndex] = "legacySamples";
+	    sampleLoadingState.urlTable[chipWaveIndex] = bundledSamplePacks.legacy;
 	}
 
 	loadScript("samples.js")
@@ -736,7 +743,7 @@ export function loadBuiltInSamples(set: number): void {
 	    Config.chipWaves[chipWaveIndex] = integratedChipWave;
 	    Config.chipWaves.dictionary[chipWave.name] = rawChipWave;
 	    sampleLoadingState.statusTable[chipWaveIndex] = SampleLoadingStatus.loading;
-	    sampleLoadingState.urlTable[chipWaveIndex] = "nintariboxSamples";
+	    sampleLoadingState.urlTable[chipWaveIndex] = bundledSamplePacks.nintaribox;
 	}
 
 	loadScript("nintaribox_samples.js")
@@ -798,7 +805,7 @@ export function loadBuiltInSamples(set: number): void {
 	    Config.chipWaves[chipWaveIndex] = integratedChipWave;
 	    Config.chipWaves.dictionary[chipWave.name] = rawChipWave;
 	    sampleLoadingState.statusTable[chipWaveIndex] = SampleLoadingStatus.loading;
-	    sampleLoadingState.urlTable[chipWaveIndex] = "marioPaintboxSamples";
+	    sampleLoadingState.urlTable[chipWaveIndex] = bundledSamplePacks.mariopaintbox;
 	}
 
 	loadScript("mario_paintbox_samples.js")

--- a/synth/synth.ts
+++ b/synth/synth.ts
@@ -553,7 +553,7 @@ export class Pattern {
         }
 
         if (patternObject["notes"] && patternObject["notes"].length > 0) {
-            const maxNoteCount: number = Math.min(song.beatsPerBar * Config.partsPerBeat * (isModChannel ? Config.modCount : 1), patternObject["notes"].length >>> 0);
+            const maxNoteCount: number = Math.min(song.partsPerPattern * (isModChannel ? Config.modCount : 1), patternObject["notes"].length >>> 0);
 
             // TODO: Consider supporting notes specified in any timing order, sorting them and truncating as necessary.
             //let tickClock: number = 0;
@@ -605,7 +605,7 @@ export class Pattern {
                         size = ((pointObject["forMod"] | 0) > 0) ? Math.round(pointObject["volume"] | 0) : Math.max(0, Math.min(volumeCap, Math.round((pointObject["volume"] | 0) * volumeCap / 100)));
                     }
 
-                    if (time > song.beatsPerBar * Config.partsPerBeat) continue;
+                    if (time > song.partsPerPattern) continue;
                     if (note.pins.length == 0) {
                         //if (time < noteClock) continue;
                         note.start = time;
@@ -2892,6 +2892,10 @@ export class Song {
         }
     }
 
+    public get partsPerPattern() {
+        return this.beatsPerBar * Config.partsPerBeat;
+    }
+
     // Returns the ideal new note volume when dragging (max volume for a normal note, a "neutral" value for mod notes based on how they work)
     public getNewNoteVolume = (isMod: boolean, modChannel?: number, modInstrument?: number, modCount?: number): number => {
         if (!isMod || modChannel == undefined || modInstrument == undefined || modCount == undefined)
@@ -3664,10 +3668,10 @@ export class Song {
                         curPart = note.end;
                     }
 
-                    if (curPart < this.beatsPerBar * Config.partsPerBeat + (+isModChannel)) {
+                    if (curPart < this.partsPerPattern + (+isModChannel)) {
                         bits.write(2, 0); // rest
                         if (isModChannel) bits.write(1, 0); // positive offset
-                        bits.writePartDuration(this.beatsPerBar * Config.partsPerBeat + (+isModChannel) - curPart);
+                        bits.writePartDuration(this.partsPerPattern + (+isModChannel) - curPart);
                     }
                 } else {
                     bits.write(1, 0);
@@ -5537,7 +5541,7 @@ export class Song {
                         const newNotes: Note[] = newPattern.notes;
                         let noteCount: number = 0;
                         // Due to arbitrary note positioning, mod channels don't end the count until curPart actually exceeds the max
-                        while (curPart < this.beatsPerBar * Config.partsPerBeat + (+isModChannel)) {
+                        while (curPart < this.partsPerPattern + (+isModChannel)) {
 
                             const useOldShape: boolean = bits.read(1) == 1;
                             let newNote: boolean = false;
@@ -5723,7 +5727,7 @@ export class Song {
                                     }
                                 }
 
-                                curPart = validateRange(0, this.beatsPerBar * Config.partsPerBeat, note.end);
+                                curPart = validateRange(0, this.partsPerPattern, note.end);
                             }
                         }
                         newNotes.length = noteCount;

--- a/synth/synth.ts
+++ b/synth/synth.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2022 John Nesky and contributing authors, distributed under the MIT license, see accompanying the LICENSE.md file.
 
-import { startLoadingSample, sampleLoadingState, SampleLoadingState, sampleLoadEvents, SampleLoadedEvent, SampleLoadingStatus, loadBuiltInSamples, Dictionary, DictionaryArray, toNameMap, FilterType, SustainType, EnvelopeType, InstrumentType, EffectType, EnvelopeComputeIndex, Transition, Unison, Chord, Vibrato, Envelope, AutomationTarget, Config, getDrumWave, drawNoiseSpectrum, getArpeggioPitchIndex, performIntegralOld, getPulseWidthRatio, effectsIncludeTransition, effectsIncludeChord, effectsIncludePitchShift, effectsIncludeDetune, effectsIncludeVibrato, effectsIncludeNoteFilter, effectsIncludeDistortion, effectsIncludeBitcrusher, effectsIncludePanning, effectsIncludeChorus, effectsIncludeEcho, effectsIncludeReverb, OperatorWave } from "./SynthConfig";
+import { startLoadingSample, sampleLoadingState, SampleLoadingState, sampleLoadEvents, SampleLoadedEvent, SampleLoadingStatus, loadBuiltInSamples, Dictionary, DictionaryArray, toNameMap, FilterType, SustainType, EnvelopeType, InstrumentType, EffectType, EnvelopeComputeIndex, Transition, Unison, Chord, Vibrato, Envelope, AutomationTarget, Config, getDrumWave, drawNoiseSpectrum, getArpeggioPitchIndex, performIntegralOld, getPulseWidthRatio, effectsIncludeTransition, effectsIncludeChord, effectsIncludePitchShift, effectsIncludeDetune, effectsIncludeVibrato, effectsIncludeNoteFilter, effectsIncludeDistortion, effectsIncludeBitcrusher, effectsIncludePanning, effectsIncludeChorus, effectsIncludeEcho, effectsIncludeReverb, OperatorWave, bundledSamplePacks } from "./SynthConfig";
 import { Preset, EditorConfig } from "../editor/EditorConfig";
 import { scaleElementsByFactor, inverseRealFourierTransform } from "./FFT";
 import { Deque } from "./Deque";
@@ -3812,21 +3812,21 @@ export class Song {
                         sampleLoadingState.samplesLoaded
                     ));
                     for (const url of compressed_array) {
-                        if (url.toLowerCase() === "legacysamples") {
+                        if (url.toLowerCase() === bundledSamplePacks.legacy) {
                             if (!willLoadLegacySamples) {
                                 willLoadLegacySamples = true;
                                 customSampleUrls.push(url);
                                 loadBuiltInSamples(0);
                             }
                         } 
-                        else if (url.toLowerCase() === "nintariboxsamples") {
+                        else if (url.toLowerCase() === bundledSamplePacks.nintaribox) {
                             if (!willLoadNintariboxSamples) {
                                 willLoadNintariboxSamples = true;
                                 customSampleUrls.push(url);
                                 loadBuiltInSamples(1);
                             }
                         }
-                        else if (url.toLowerCase() === "mariopaintboxsamples") {
+                        else if (url.toLowerCase() === bundledSamplePacks.mariopaintbox) {
                             if (!willLoadMarioPaintboxSamples) {
                                 willLoadMarioPaintboxSamples = true;
                                 customSampleUrls.push(url);
@@ -4407,11 +4407,11 @@ export class Song {
                     }
                 }
                 else if (fromGoldBox && !beforeFour && beforeSix) {
-                    if (document.URL.substring(document.URL.length - 13).toLowerCase() != "legacysamples") {
+                    if (document.URL.substring(document.URL.length - 13).toLowerCase() != bundledSamplePacks.legacy) {
                             if (!willLoadLegacySamplesForOldSongs) {
                                 willLoadLegacySamplesForOldSongs = true;
                                 Config.willReloadForCustomSamples = true;
-                                EditorConfig.customSamples = ["legacySamples"];
+                                EditorConfig.customSamples = [bundledSamplePacks.legacy];
                                 loadBuiltInSamples(0);
                             }
                     }
@@ -5097,11 +5097,11 @@ export class Song {
                     //is it more useful to save base64 characters or url length?
                     const chipWaveForCompat = base64CharCodeToInt[compressed.charCodeAt(charIndex++)];
                     if ((chipWaveForCompat + 62) > 85) {
-                        if (document.URL.substring(document.URL.length - 13).toLowerCase() != "legacysamples") {
+                        if (document.URL.substring(document.URL.length - 13).toLowerCase() != bundledSamplePacks.legacy) {
                             if (!willLoadLegacySamplesForOldSongs) {
                                 willLoadLegacySamplesForOldSongs = true;
                                 Config.willReloadForCustomSamples = true;
-                                EditorConfig.customSamples = ["legacySamples"];
+                                EditorConfig.customSamples = [bundledSamplePacks.legacy];
                                 loadBuiltInSamples(0);
                             }
                         }
@@ -6212,21 +6212,21 @@ export class Song {
                 const customSampleUrls: string[] = [];
                 const customSamplePresets: Preset[] = [];
                 for (const url of customSamples) {
-                    if (url.toLowerCase() === "legacysamples") {
+                    if (url.toLowerCase() === bundledSamplePacks.legacy) {
                         if (!willLoadLegacySamples) {
                             willLoadLegacySamples = true;
                             customSampleUrls.push(url);
                             loadBuiltInSamples(0);
                         }
                     } 
-                    else if (url.toLowerCase() === "nintariboxsamples") {
+                    else if (url.toLowerCase() === bundledSamplePacks.nintaribox) {
                         if (!willLoadNintariboxSamples) {
                             willLoadNintariboxSamples = true;
                             customSampleUrls.push(url);
                             loadBuiltInSamples(1);
                         }
                     }
-                    else if (url.toLowerCase() === "mariopaintboxsamples") {
+                    else if (url.toLowerCase() === bundledSamplePacks.mariopaintbox) {
                         if (!willLoadMarioPaintboxSamples) {
                             willLoadMarioPaintboxSamples = true;
                             customSampleUrls.push(url);
@@ -6493,7 +6493,7 @@ export class Song {
                 Song._restoreChipWaveListToDefault();
 
                 loadBuiltInSamples(0);
-                EditorConfig.customSamples = ["legacySamples"];
+                EditorConfig.customSamples = [bundledSamplePacks.legacy];
             } else {
                 // We don't need to load the legacy samples, but we may have
                 // leftover samples in memory. If we do, clear them.


### PR DESCRIPTION
Mute Editor fix
- When an index is selected, dropdown is supposed to close (display = none) but was display = '', which causes Firefox to get stuck with the name display visible and only pressing enter/escape closes it. I thought this was committed already..

Mute Editor improved
- Now displays Unmute and Un-solo as appropriate for a little more interactivity. Very minor change, just QoL

Other refactoring
- Bundled strings are magic strings floating around and are now typed
- `partsPerPattern` replaces `doc.song.beatsPerBar * Config.partsPerBeat` to reduce verbosity around the repo. I triple this number in my fork, so I'd like to keep this refactoring.